### PR TITLE
Allow managing face clusters through DAV

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -75,5 +75,16 @@ The app does not send any sensitive data to cloud providers or similar services.
 
 	<types>
 		<filesystem/>
+		<dav/>
 	</types>
+
+
+	<sabre>
+		<collections>
+			<collection>OCA\Recognize\Dav\RootCollection</collection>
+		</collections>
+		<plugins>
+			<plugin>OCA\Recognize\Dav\Faces\PropFindPlugin</plugin>
+		</plugins>
+	</sabre>
 </info>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -8,6 +8,7 @@
 
 namespace OCA\Recognize\AppInfo;
 
+use OCA\DAV\Connector\Sabre\Principal;
 use OCA\Recognize\Hooks\FileListener;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
@@ -32,6 +33,8 @@ class Application extends App implements IBootstrap {
 
 	public function register(IRegistrationContext $context): void {
 		@include_once __DIR__ . '/../../vendor/autoload.php';
+		/** Register $principalBackend for the DAV collection */
+		$context->registerServiceAlias('principalBackend', Principal::class);
 	}
 
 	/**

--- a/lib/Dav/Faces/FacePhoto.php
+++ b/lib/Dav/Faces/FacePhoto.php
@@ -128,7 +128,7 @@ class FacePhoto implements IFile {
 		return $this->getFile()->getMTime();
 	}
 
-	public function getMetadata(): string {
+	public function getMetadata(): array {
 		$file = $this->getFile();
 		$sizeMetadata = $this->metadataManager->fetchMetadataFor('size', [$file->getId()])[$file->getId()];
 		return $sizeMetadata->getMetadata();

--- a/lib/Dav/Faces/FacePhoto.php
+++ b/lib/Dav/Faces/FacePhoto.php
@@ -6,7 +6,6 @@ use OCA\Recognize\Db\FaceCluster;
 use OCA\Recognize\Db\FaceDetection;
 use OCA\Recognize\Db\FaceDetectionMapper;
 use OCP\Files\File;
-use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
@@ -18,7 +17,6 @@ class FacePhoto implements IFile {
 	private FaceCluster $cluster;
 	private Folder $userFolder;
 	private ?File $file = null;
-	private ?FileInfo $fileInfo = null;
 
 	public const TAG_FAVORITE = '_$!<Favorite>!$_';
 
@@ -122,20 +120,6 @@ class FacePhoto implements IFile {
 		return $this->getFile()->getMTime();
 	}
 
-
-	public function getFileInfo() : FileInfo {
-		if ($this->fileInfo === null) {
-			$nodes = $this->userFolder->getById($this->getFile()->getId());
-			$node = current($nodes);
-			if ($node) {
-				return $this->fileInfo = $node->getFileInfo();
-			} else {
-				throw new NotFound("Photo not found for user");
-			}
-		}
-		return $this->fileInfo;
-	}
-
 	public function getMetadata(): array {
 		$metadataManager = \OCP\Server::get(\OC\Metadata\IMetadataManager::class);
 		$file = $this->getFile();
@@ -145,7 +129,7 @@ class FacePhoto implements IFile {
 
 	public function hasPreview(): bool {
 		$previewManager = \OCP\Server::get(\OCP\IPreview::class);
-		return $previewManager->isAvailable($this->getFileInfo());
+		return $previewManager->isAvailable($this->getFile());
 	}
 
 	public function isFavorite(): bool {

--- a/lib/Dav/Faces/FacePhoto.php
+++ b/lib/Dav/Faces/FacePhoto.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace OCA\Recognize\Dav\Faces;
+
+use OCA\Recognize\Db\FaceDetection;
+use OCA\Recognize\Db\FaceDetectionMapper;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\IFile;
+
+class FacePhoto implements IFile {
+	private FaceDetectionMapper $detectionMapper;
+	private FaceDetection $faceDetection;
+	private Folder $userFolder;
+
+	public function __construct(FaceDetectionMapper $detectionMapper, FaceDetection $faceDetection, Folder $userFolder) {
+		$this->detectionMapper = $detectionMapper;
+		$this->faceDetection = $faceDetection;
+		$this->userFolder = $userFolder;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getName() {
+		$file = $this->getFile();
+		return $file->getId() . '-' . $file->getName();
+	}
+
+	/**
+	 * @inheritDoc
+	 * @throws \OCP\DB\Exception
+	 */
+	public function delete() {
+		$this->faceDetection->setClusterId(null);
+		$this->detectionMapper->update($this->faceDetection);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setName($name) {
+		throw new Forbidden('Cannot rename photos through faces API');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function put($data) {
+		throw new Forbidden('Can\'t write to photos trough the faces api');
+	}
+
+	public function getFile() : File {
+		$nodes = $this->userFolder->getById($this->faceDetection->getFileId());
+		$node = current($nodes);
+		if ($node) {
+			if ($node instanceof File) {
+				return $node;
+			} else {
+				throw new NotFound("Photo is a folder");
+			}
+		} else {
+			throw new NotFound("Photo not found for user");
+		}
+	}
+
+	public function getFaceDetection() : FaceDetection {
+		return $this->faceDetection;
+	}
+
+	/**
+	 * @inheritDoc
+	 * @throws \Sabre\DAV\Exception\NotFound
+	 */
+	public function get() {
+		return $this->getFile()->fopen('r');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getContentType() {
+		return $this->getFile()->getMimeType();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getETag() {
+		return $this->getFile()->getEtag();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getSize() {
+		return $this->getFile()->getSize();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getLastModified() {
+		return $this->getFile()->getMTime();
+	}
+}

--- a/lib/Dav/Faces/FaceRoot.php
+++ b/lib/Dav/Faces/FaceRoot.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace OCA\Recognize\Dav\Faces;
+
+use OCA\Recognize\Db\FaceCluster;
+use OCA\Recognize\Db\FaceClusterMapper;
+use OCA\Recognize\Db\FaceDetection;
+use OCA\Recognize\Db\FaceDetectionMapper;
+use OCP\Files\IRootFolder;
+use OCP\IUser;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+use Sabre\DAV\IMoveTarget;
+use Sabre\DAV\INode;
+
+class FaceRoot implements ICollection, IMoveTarget {
+	private FaceClusterMapper $clusterMapper;
+	private FaceCluster $cluster;
+	private IUser $user;
+	private FaceDetectionMapper $detectionMapper;
+	private IRootFolder $rootFolder;
+
+	public function __construct(FaceClusterMapper $clusterMapper, FaceCluster $cluster, IUser $user, FaceDetectionMapper $detectionMapper, IRootFolder $rootFolder) {
+		$this->clusterMapper = $clusterMapper;
+		$this->cluster = $cluster;
+		$this->user = $user;
+		$this->detectionMapper = $detectionMapper;
+		$this->rootFolder = $rootFolder;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getName() {
+		return $this->cluster->getTitle() !== '' ? $this->cluster->getTitle() : 'Person '.$this->cluster->getId();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function setName($name) {
+		$this->cluster->setTitle(basename($name));
+		$this->clusterMapper->update($this->cluster);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function createDirectory($name) {
+		throw new Forbidden('Not allowed to create directories in this folder');
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function createFile($name, $data = null) {
+		throw new Forbidden('Not allowed to create files in this folder');
+	}
+
+	/**
+	 * @throws \OCP\Files\NotPermittedException
+	 * @throws \OC\User\NoUserException
+	 */
+	public function getChildren(): array {
+		return array_map(function (FaceDetection $detection) {
+			return new FacePhoto($this->detectionMapper, $detection, $this->rootFolder->getUserFolder($this->user->getUID()));
+		}, $this->detectionMapper->findByClusterId($this->cluster->getId()));
+	}
+
+	public function getChild($name): FacePhoto {
+		foreach ($this->getChildren() as $child) {
+			if ($child->getName() === $name) {
+				return $child;
+			}
+		}
+		throw new NotFound("$name not found");
+	}
+
+	public function childExists($name): bool {
+		try {
+			$this->getChild($name);
+			return true;
+		} catch (NotFound $e) {
+			return false;
+		}
+	}
+
+	public function moveInto($targetName, $sourcePath, INode $sourceNode) {
+		if ($sourceNode instanceof FacePhoto) {
+			$sourceNode->getFaceDetection()->setClusterId($this->cluster->getId());
+			$this->detectionMapper->update($sourceNode->getFaceDetection());
+			return true;
+		}
+		throw new Forbidden('Not a photo with a detected face, you can only move photos from the faces collection here');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @throws \OCP\DB\Exception
+	 */
+	public function delete() {
+		$this->clusterMapper->delete($this->cluster);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getLastModified() : int {
+		return 0;
+	}
+}

--- a/lib/Dav/Faces/FaceRoot.php
+++ b/lib/Dav/Faces/FaceRoot.php
@@ -29,7 +29,7 @@ class FaceRoot implements ICollection, IMoveTarget {
 	/**
 	 * @var \OCA\Recognize\Dav\Faces\FacePhoto[]
 	 */
-	private array $children;
+	private array $children = [];
 
 	public function __construct(FaceClusterMapper $clusterMapper, FaceCluster $cluster, IUser $user, FaceDetectionMapper $detectionMapper, IRootFolder $rootFolder, IMetadataManager $metadataManager, ITagManager $tagManager, IPreview $previewManager) {
 		$this->clusterMapper = $clusterMapper;

--- a/lib/Dav/Faces/FaceRoot.php
+++ b/lib/Dav/Faces/FaceRoot.php
@@ -26,6 +26,10 @@ class FaceRoot implements ICollection, IMoveTarget {
 	private IMetadataManager $metadataManager;
 	private ITagManager $tagManager;
 	private IPreview $previewManager;
+	/**
+	 * @var \OCA\Recognize\Dav\Faces\FacePhoto[]
+	 */
+	private array $children;
 
 	public function __construct(FaceClusterMapper $clusterMapper, FaceCluster $cluster, IUser $user, FaceDetectionMapper $detectionMapper, IRootFolder $rootFolder, IMetadataManager $metadataManager, ITagManager $tagManager, IPreview $previewManager) {
 		$this->clusterMapper = $clusterMapper;
@@ -72,9 +76,12 @@ class FaceRoot implements ICollection, IMoveTarget {
 	 * @throws \OC\User\NoUserException
 	 */
 	public function getChildren(): array {
-		return array_map(function (FaceDetection $detection) {
-			return new FacePhoto($this->detectionMapper, $this->cluster, $detection, $this->rootFolder->getUserFolder($this->user->getUID()), $this->tagManager, $this->metadataManager, $this->previewManager);
-		}, $this->detectionMapper->findByClusterId($this->cluster->getId()));
+		if (count($this->children) === 0) {
+			$this->children = array_map(function (FaceDetection $detection) {
+				return new FacePhoto($this->detectionMapper, $this->cluster, $detection, $this->rootFolder->getUserFolder($this->user->getUID()), $this->tagManager, $this->metadataManager, $this->previewManager);
+			}, $this->detectionMapper->findByClusterId($this->cluster->getId()));
+		}
+		return $this->children;
 	}
 
 	public function getChild($name): FacePhoto {

--- a/lib/Dav/Faces/FaceRoot.php
+++ b/lib/Dav/Faces/FaceRoot.php
@@ -33,7 +33,7 @@ class FaceRoot implements ICollection, IMoveTarget {
 	 * @inheritDoc
 	 */
 	public function getName() {
-		return $this->cluster->getTitle() !== '' ? $this->cluster->getTitle() : 'Person '.$this->cluster->getId();
+		return $this->cluster->getTitle() !== '' ? $this->cluster->getTitle() : ''.$this->cluster->getId();
 	}
 
 	/**

--- a/lib/Dav/Faces/FaceRoot.php
+++ b/lib/Dav/Faces/FaceRoot.php
@@ -64,7 +64,7 @@ class FaceRoot implements ICollection, IMoveTarget {
 	 */
 	public function getChildren(): array {
 		return array_map(function (FaceDetection $detection) {
-			return new FacePhoto($this->detectionMapper, $detection, $this->rootFolder->getUserFolder($this->user->getUID()));
+			return new FacePhoto($this->detectionMapper, $this->cluster, $detection, $this->rootFolder->getUserFolder($this->user->getUID()));
 		}, $this->detectionMapper->findByClusterId($this->cluster->getId()));
 	}
 

--- a/lib/Dav/Faces/FaceRoot.php
+++ b/lib/Dav/Faces/FaceRoot.php
@@ -2,11 +2,14 @@
 
 namespace OCA\Recognize\Dav\Faces;
 
+use OC\Metadata\IMetadataManager;
 use OCA\Recognize\Db\FaceCluster;
 use OCA\Recognize\Db\FaceClusterMapper;
 use OCA\Recognize\Db\FaceDetection;
 use OCA\Recognize\Db\FaceDetectionMapper;
 use OCP\Files\IRootFolder;
+use OCP\IPreview;
+use OCP\ITagManager;
 use OCP\IUser;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
@@ -20,13 +23,19 @@ class FaceRoot implements ICollection, IMoveTarget {
 	private IUser $user;
 	private FaceDetectionMapper $detectionMapper;
 	private IRootFolder $rootFolder;
+	private IMetadataManager $metadataManager;
+	private ITagManager $tagManager;
+	private IPreview $previewManager;
 
-	public function __construct(FaceClusterMapper $clusterMapper, FaceCluster $cluster, IUser $user, FaceDetectionMapper $detectionMapper, IRootFolder $rootFolder) {
+	public function __construct(FaceClusterMapper $clusterMapper, FaceCluster $cluster, IUser $user, FaceDetectionMapper $detectionMapper, IRootFolder $rootFolder, IMetadataManager $metadataManager, ITagManager $tagManager, IPreview $previewManager) {
 		$this->clusterMapper = $clusterMapper;
 		$this->cluster = $cluster;
 		$this->user = $user;
 		$this->detectionMapper = $detectionMapper;
 		$this->rootFolder = $rootFolder;
+		$this->metadataManager = $metadataManager;
+		$this->tagManager = $tagManager;
+		$this->previewManager = $previewManager;
 	}
 
 	/**
@@ -64,7 +73,7 @@ class FaceRoot implements ICollection, IMoveTarget {
 	 */
 	public function getChildren(): array {
 		return array_map(function (FaceDetection $detection) {
-			return new FacePhoto($this->detectionMapper, $this->cluster, $detection, $this->rootFolder->getUserFolder($this->user->getUID()));
+			return new FacePhoto($this->detectionMapper, $this->cluster, $detection, $this->rootFolder->getUserFolder($this->user->getUID()), $this->tagManager, $this->metadataManager, $this->previewManager);
 		}, $this->detectionMapper->findByClusterId($this->cluster->getId()));
 	}
 

--- a/lib/Dav/Faces/FaceRoot.php
+++ b/lib/Dav/Faces/FaceRoot.php
@@ -86,6 +86,14 @@ class FaceRoot implements ICollection, IMoveTarget {
 	}
 
 	public function getChild($name): FacePhoto {
+		if (count($this->children) !== 0) {
+			foreach ($this->getChildren() as $child) {
+				if ($child->getName() === $name) {
+					return $child;
+				}
+			}
+			throw new NotFound("$name not found");
+		}
 		[$fileId,] = explode('-', $name);
 		try {
 			$detection = $this->detectionMapper->findByFileIdAndClusterId((int)$fileId, $this->cluster->getId());

--- a/lib/Dav/Faces/FacesHome.php
+++ b/lib/Dav/Faces/FacesHome.php
@@ -2,10 +2,13 @@
 
 namespace OCA\Recognize\Dav\Faces;
 
+use OC\Metadata\IMetadataManager;
 use OCA\Recognize\Db\FaceCluster;
 use OCA\Recognize\Db\FaceClusterMapper;
 use OCA\Recognize\Db\FaceDetectionMapper;
 use OCP\Files\IRootFolder;
+use OCP\IPreview;
+use OCP\ITagManager;
 use OCP\IUser;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
@@ -17,12 +20,18 @@ class FacesHome implements ICollection {
 	private FaceDetectionMapper $faceDetectionMapper;
 	private IRootFolder $rootFolder;
 	private array $children = [];
+	private ITagManager $tagManager;
+	private IMetadataManager $metadataManager;
+	private IPreview $previewManager;
 
-	public function __construct(FaceClusterMapper $faceClusterMapper, IUser $user, FaceDetectionMapper $faceDetectionMapper, IRootFolder $rootFolder) {
+	public function __construct(FaceClusterMapper $faceClusterMapper, IUser $user, FaceDetectionMapper $faceDetectionMapper, IRootFolder $rootFolder, ITagManager $tagManager, IMetadataManager $metadataManager, IPreview $previewManager) {
 		$this->faceClusterMapper = $faceClusterMapper;
 		$this->user = $user;
 		$this->faceDetectionMapper = $faceDetectionMapper;
 		$this->rootFolder = $rootFolder;
+		$this->tagManager = $tagManager;
+		$this->metadataManager = $metadataManager;
+		$this->previewManager = $previewManager;
 	}
 
 	public function delete() {
@@ -63,7 +72,7 @@ class FacesHome implements ICollection {
 		$clusters = $this->faceClusterMapper->findByUserId($this->user->getUID());
 		if (count($this->children) === 0) {
 			$this->children = array_map(function (FaceCluster $cluster) {
-				return new FaceRoot($this->faceClusterMapper, $cluster, $this->user, $this->faceDetectionMapper, $this->rootFolder);
+				return new FaceRoot($this->faceClusterMapper, $cluster, $this->user, $this->faceDetectionMapper, $this->rootFolder, $this->metadataManager, $this->tagManager, $this->previewManager);
 			}, $clusters);
 		}
 		return $this->children;

--- a/lib/Dav/Faces/FacesHome.php
+++ b/lib/Dav/Faces/FacesHome.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace OCA\Recognize\Dav\Faces;
+
+use OCA\Recognize\Db\FaceCluster;
+use OCA\Recognize\Db\FaceClusterMapper;
+use OCA\Recognize\Db\FaceDetectionMapper;
+use OCP\Files\IRootFolder;
+use OCP\IUser;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+
+class FacesHome implements ICollection {
+	private FaceClusterMapper $faceClusterMapper;
+	private IUser $user;
+	private FaceDetectionMapper $faceDetectionMapper;
+	private IRootFolder $rootFolder;
+
+	public function __construct(FaceClusterMapper $faceClusterMapper, IUser $user, FaceDetectionMapper $faceDetectionMapper, IRootFolder $rootFolder) {
+		$this->faceClusterMapper = $faceClusterMapper;
+		$this->user = $user;
+		$this->faceDetectionMapper = $faceDetectionMapper;
+		$this->rootFolder = $rootFolder;
+	}
+
+	public function delete() {
+		throw new Forbidden();
+	}
+
+	public function getName(): string {
+		return 'faces';
+	}
+
+	public function setName($name) {
+		throw new Forbidden('Permission denied to rename this folder');
+	}
+
+	public function createDirectory($name) {
+		throw new Forbidden('Not allowed to create directories in this folder');
+	}
+
+	public function createFile($name, $data = null) {
+		throw new Forbidden('Not allowed to create files in this folder');
+	}
+
+	public function getChild($name) {
+		foreach ($this->getChildren() as $child) {
+			if ($child->getName() === $name) {
+				return $child;
+			}
+		}
+
+		throw new NotFound();
+	}
+
+	/**
+	 * @return \OCA\Recognize\Dav\Faces\FaceRoot[]
+	 * @throws \OCP\DB\Exception
+	 */
+	public function getChildren(): array {
+		$clusters = $this->faceClusterMapper->findByUserId($this->user->getUID());
+		return array_map(function (FaceCluster $cluster) {
+			return new FaceRoot($this->faceClusterMapper, $cluster, $this->user, $this->faceDetectionMapper, $this->rootFolder);
+		}, $clusters);
+	}
+
+	public function childExists($name): bool {
+		try {
+			$this->getChild($name);
+			return true;
+		} catch (NotFound $e) {
+			return false;
+		}
+	}
+
+	public function getLastModified(): int {
+		return 0;
+	}
+}

--- a/lib/Dav/Faces/FacesHome.php
+++ b/lib/Dav/Faces/FacesHome.php
@@ -63,6 +63,9 @@ class FacesHome implements ICollection {
 		} catch (DoesNotExistException $e) {
 			try {
 				$cluster = $this->faceClusterMapper->find((int) $name);
+				if ($cluster->getUserId() !== $this->user->getUID()) {
+					throw new NotFound();
+				}
 			} catch (DoesNotExistException $e) {
 				throw new NotFound();
 			}

--- a/lib/Dav/Faces/FacesHome.php
+++ b/lib/Dav/Faces/FacesHome.php
@@ -57,7 +57,15 @@ class FacesHome implements ICollection {
 		throw new Forbidden('Not allowed to create files in this folder');
 	}
 
-	public function getChild($name) {
+	public function getChild($name) : FaceRoot {
+		if (count($this->children) !== 0) {
+			foreach ($this->getChildren() as $child) {
+				if ($child->getName() === $name) {
+					return $child;
+				}
+			}
+			throw new NotFound();
+		}
 		try {
 			$cluster = $this->faceClusterMapper->findByUserAndTitle($this->user->getUID(), $name);
 		} catch (DoesNotExistException $e) {

--- a/lib/Dav/Faces/FacesHome.php
+++ b/lib/Dav/Faces/FacesHome.php
@@ -16,6 +16,7 @@ class FacesHome implements ICollection {
 	private IUser $user;
 	private FaceDetectionMapper $faceDetectionMapper;
 	private IRootFolder $rootFolder;
+	private array $children = [];
 
 	public function __construct(FaceClusterMapper $faceClusterMapper, IUser $user, FaceDetectionMapper $faceDetectionMapper, IRootFolder $rootFolder) {
 		$this->faceClusterMapper = $faceClusterMapper;
@@ -60,9 +61,12 @@ class FacesHome implements ICollection {
 	 */
 	public function getChildren(): array {
 		$clusters = $this->faceClusterMapper->findByUserId($this->user->getUID());
-		return array_map(function (FaceCluster $cluster) {
-			return new FaceRoot($this->faceClusterMapper, $cluster, $this->user, $this->faceDetectionMapper, $this->rootFolder);
-		}, $clusters);
+		if (count($this->children) === 0) {
+			$this->children = array_map(function (FaceCluster $cluster) {
+				return new FaceRoot($this->faceClusterMapper, $cluster, $this->user, $this->faceDetectionMapper, $this->rootFolder);
+			}, $clusters);
+		}
+		return $this->children;
 	}
 
 	public function childExists($name): bool {

--- a/lib/Dav/Faces/PropFindPlugin.php
+++ b/lib/Dav/Faces/PropFindPlugin.php
@@ -6,6 +6,7 @@ use OCA\DAV\Connector\Sabre\File;
 use OCA\Recognize\Db\FaceClusterMapper;
 use OCA\Recognize\Db\FaceDetection;
 use OCA\Recognize\Db\FaceDetectionMapper;
+use OCA\Recognize\Db\FaceDetectionWithTitle;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
@@ -40,11 +41,7 @@ class PropFindPlugin extends ServerPlugin {
 			});
 
 			$propFind->handle('{http://nextcloud.org/ns}face-detections', function () use ($node) {
-				return json_encode(array_map(function (FaceDetection $face) {
-					$array = $face->toArray();
-					$array['faceName'] = $this->clusterMapper->find($face->getClusterId())->getTitle() === ''? 'Person ' . $face->getClusterId() : $this->clusterMapper->find($face->getClusterId())->getTitle();
-					return $array;
-				}, array_values(array_filter($this->faceDetectionMapper->findByFileId($node->getFile()->getId()), fn (FaceDetection $face) => $face->getClusterId() !== null))));
+				return json_encode(array_map(fn (FaceDetectionWithTitle $face) => $face->toArray(), array_values(array_filter($this->faceDetectionMapper->findByFileIdWithTitle($node->getFile()->getId()), fn (FaceDetection $face) => $face->getClusterId() !== null))));
 			});
 
 			$propFind->handle(self::INTERNAL_FILEID_PROPERTYNAME, fn () => $node->getFile()->getId());
@@ -57,11 +54,7 @@ class PropFindPlugin extends ServerPlugin {
 
 		if ($node instanceof File) {
 			$propFind->handle('{http://nextcloud.org/ns}face-detections', function () use ($node) {
-				return json_encode(array_map(function (FaceDetection $face) {
-					$array = $face->toArray();
-					$array['faceName'] = $this->clusterMapper->find($face->getClusterId())->getTitle() === ''? 'Person ' . $face->getClusterId() : $this->clusterMapper->find($face->getClusterId())->getTitle();
-					return $array;
-				}, array_values(array_filter($this->faceDetectionMapper->findByFileId($node->getId()), fn (FaceDetection $face) => $face->getClusterId() !== null))));
+				return json_encode(array_map(fn (FaceDetectionWithTitle $face) => $face->toArray(), array_values(array_filter($this->faceDetectionMapper->findByFileIdWithTitle($node->getId()), fn (FaceDetection $face) => $face->getClusterId() !== null))));
 			});
 		}
 	}

--- a/lib/Dav/Faces/PropFindPlugin.php
+++ b/lib/Dav/Faces/PropFindPlugin.php
@@ -3,8 +3,8 @@
 namespace OCA\Recognize\Dav\Faces;
 
 use OCA\DAV\Connector\Sabre\File;
-use OCA\DAV\Connector\Sabre\FilesPlugin;
-use OCA\DAV\Connector\Sabre\TagsPlugin;
+use \OCA\DAV\Connector\Sabre\FilesPlugin;
+use \OCA\DAV\Connector\Sabre\TagsPlugin;
 use OCA\Recognize\Db\FaceDetection;
 use OCA\Recognize\Db\FaceDetectionMapper;
 use OCA\Recognize\Db\FaceDetectionWithTitle;

--- a/lib/Dav/Faces/PropFindPlugin.php
+++ b/lib/Dav/Faces/PropFindPlugin.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace OCA\Recognize\Dav\Faces;
+
+use Sabre\DAV\INode;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+
+class PropFindPlugin extends ServerPlugin {
+	private Server $server;
+
+	public function initialize(Server $server) {
+		$this->server = $server;
+
+		$this->server->on('propFind', [$this, 'propFind']);
+	}
+
+
+	public function propFind(PropFind $propFind, INode $node) {
+		if (!($node instanceof FacePhoto)) {
+			return;
+		}
+
+		$propFind->handle('{http://nextcloud.org/ns}file-name', function () use ($node) {
+			return $node->getFile()->getName();
+		});
+	}
+}

--- a/lib/Dav/Faces/PropFindPlugin.php
+++ b/lib/Dav/Faces/PropFindPlugin.php
@@ -46,7 +46,7 @@ class PropFindPlugin extends ServerPlugin {
 
 			$propFind->handle(self::INTERNAL_FILEID_PROPERTYNAME, fn () => $node->getFile()->getId());
 			$propFind->handle('{http://nextcloud.org/ns}file-name', fn () => $node->getFile()->getName());
-			$propFind->handle('{http://nextcloud.org/ns}realpath', fn () => $node->getFileInfo()->getPath());
+			$propFind->handle('{http://nextcloud.org/ns}realpath', fn () => $node->getFile()->getPath());
 			$propFind->handle(self::FILE_METADATA_SIZE, fn () => json_encode($node->getMetadata()));
 			$propFind->handle(self::HAS_PREVIEW_PROPERTYNAME, fn () => json_encode($node->hasPreview()));
 			$propFind->handle(self::FAVORITE_PROPERTYNAME, fn () => $node->isFavorite() ? 1 : 0);

--- a/lib/Dav/Faces/PropFindPlugin.php
+++ b/lib/Dav/Faces/PropFindPlugin.php
@@ -3,7 +3,8 @@
 namespace OCA\Recognize\Dav\Faces;
 
 use OCA\DAV\Connector\Sabre\File;
-use OCA\Recognize\Db\FaceClusterMapper;
+use OCA\DAV\Connector\Sabre\FilesPlugin;
+use OCA\DAV\Connector\Sabre\TagsPlugin;
 use OCA\Recognize\Db\FaceDetection;
 use OCA\Recognize\Db\FaceDetectionMapper;
 use OCA\Recognize\Db\FaceDetectionWithTitle;
@@ -13,18 +14,15 @@ use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 
 class PropFindPlugin extends ServerPlugin {
+	public const FACE_DETECTIONS_PROPERTYNAME = '{http://nextcloud.org/ns}face-detections';
+	public const FILE_NAME_PROPERTYNAME = '{http://nextcloud.org/ns}file-name';
+	public const REALPATH_PROPERTYNAME = '{http://nextcloud.org/ns}realpath';
+
 	private Server $server;
 	private FaceDetectionMapper $faceDetectionMapper;
-	private FaceClusterMapper $clusterMapper;
 
-	public const INTERNAL_FILEID_PROPERTYNAME = '{http://owncloud.org/ns}fileid';
-	public const FILE_METADATA_SIZE = '{http://nextcloud.org/ns}file-metadata-size';
-	public const HAS_PREVIEW_PROPERTYNAME = '{http://nextcloud.org/ns}has-preview';
-	public const FAVORITE_PROPERTYNAME = '{http://owncloud.org/ns}favorite';
-
-	public function __construct(FaceDetectionMapper $faceDetectionMapper, FaceClusterMapper $clusterMapper) {
+	public function __construct(FaceDetectionMapper $faceDetectionMapper) {
 		$this->faceDetectionMapper = $faceDetectionMapper;
-		$this->clusterMapper = $clusterMapper;
 	}
 
 	public function initialize(Server $server) {
@@ -36,24 +34,24 @@ class PropFindPlugin extends ServerPlugin {
 
 	public function propFind(PropFind $propFind, INode $node) {
 		if ($node instanceof FacePhoto) {
-			$propFind->handle('{http://nextcloud.org/ns}file-name', function () use ($node) {
+			$propFind->handle(self::FILE_NAME_PROPERTYNAME, function () use ($node) {
 				return $node->getFile()->getName();
 			});
 
-			$propFind->handle('{http://nextcloud.org/ns}face-detections', function () use ($node) {
+			$propFind->handle(self::FACE_DETECTIONS_PROPERTYNAME, function () use ($node) {
 				return json_encode(array_map(fn (FaceDetectionWithTitle $face) => $face->toArray(), array_values(array_filter($this->faceDetectionMapper->findByFileIdWithTitle($node->getFile()->getId()), fn (FaceDetection $face) => $face->getClusterId() !== null))));
 			});
 
-			$propFind->handle(self::INTERNAL_FILEID_PROPERTYNAME, fn () => $node->getFile()->getId());
-			$propFind->handle('{http://nextcloud.org/ns}file-name', fn () => $node->getFile()->getName());
-			$propFind->handle('{http://nextcloud.org/ns}realpath', fn () => $node->getFile()->getPath());
-			$propFind->handle(self::FILE_METADATA_SIZE, fn () => json_encode($node->getMetadata()));
-			$propFind->handle(self::HAS_PREVIEW_PROPERTYNAME, fn () => json_encode($node->hasPreview()));
-			$propFind->handle(self::FAVORITE_PROPERTYNAME, fn () => $node->isFavorite() ? 1 : 0);
+			$propFind->handle(FilesPlugin::INTERNAL_FILEID_PROPERTYNAME, fn () => $node->getFile()->getId());
+			$propFind->handle(self::FILE_NAME_PROPERTYNAME, fn () => $node->getFile()->getName());
+			$propFind->handle(self::REALPATH_PROPERTYNAME, fn () => $node->getFile()->getPath());
+			$propFind->handle(FilesPlugin::FILE_METADATA_SIZE, fn () => json_encode($node->getMetadata()));
+			$propFind->handle(FilesPlugin::HAS_PREVIEW_PROPERTYNAME, fn () => json_encode($node->hasPreview()));
+			$propFind->handle(TagsPlugin::FAVORITE_PROPERTYNAME, fn () => $node->isFavorite() ? 1 : 0);
 		}
 
 		if ($node instanceof File) {
-			$propFind->handle('{http://nextcloud.org/ns}face-detections', function () use ($node) {
+			$propFind->handle(self::FACE_DETECTIONS_PROPERTYNAME, function () use ($node) {
 				return json_encode(array_map(fn (FaceDetectionWithTitle $face) => $face->toArray(), array_values(array_filter($this->faceDetectionMapper->findByFileIdWithTitle($node->getId()), fn (FaceDetection $face) => $face->getClusterId() !== null))));
 			});
 		}

--- a/lib/Dav/RecognizeHome.php
+++ b/lib/Dav/RecognizeHome.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace OCA\Recognize\Dav;
+
+use OCA\Recognize\Dav\Faces\FacesHome;
+use OCA\Recognize\Db\FaceClusterMapper;
+use OCA\Recognize\Db\FaceDetectionMapper;
+use OCP\Files\IRootFolder;
+use OCP\IUser;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+
+class RecognizeHome implements ICollection {
+	private array $principalInfo;
+	private FaceClusterMapper $faceClusterMapper;
+	private IUser $user;
+	/**
+	 * @var \OCA\Recognize\Db\FaceDetectionMapper
+	 */
+	private FaceDetectionMapper $faceDetectionMapper;
+	/**
+	 * @var \OCP\Files\IRootFolder
+	 */
+	private IRootFolder $rootFolder;
+
+	public function __construct(array $principalInfo, FaceClusterMapper $faceClusterMapper, IUser $user, FaceDetectionMapper $faceDetectionMapper, IRootFolder $rootFolder) {
+		$this->principalInfo = $principalInfo;
+		$this->faceClusterMapper = $faceClusterMapper;
+		$this->user = $user;
+		$this->faceDetectionMapper = $faceDetectionMapper;
+		$this->rootFolder = $rootFolder;
+	}
+
+	public function getName(): string {
+		[, $name] = \Sabre\Uri\split($this->principalInfo['uri']);
+		return $name;
+	}
+
+	public function setName($name) {
+		throw new Forbidden('Permission denied to rename this folder');
+	}
+
+	public function delete() {
+		throw new Forbidden();
+	}
+
+	public function createFile($name, $data = null) {
+		throw new Forbidden('Not allowed to create files in this folder');
+	}
+
+	public function createDirectory($name) {
+		throw new Forbidden('Permission denied to create folders in this folder');
+	}
+
+	public function getChild($name) {
+		if ($name === 'faces') {
+			return new FacesHome($this->faceClusterMapper, $this->user, $this->faceDetectionMapper, $this->rootFolder);
+		}
+
+		throw new NotFound();
+	}
+
+	/**
+	 * @return FacesHome[]
+	 */
+	public function getChildren(): array {
+		return [new FacesHome($this->faceClusterMapper, $this->user, $this->faceDetectionMapper, $this->rootFolder)];
+	}
+
+	public function childExists($name): bool {
+		return $name === 'faces';
+	}
+
+	public function getLastModified(): int {
+		return 0;
+	}
+}

--- a/lib/Dav/RootCollection.php
+++ b/lib/Dav/RootCollection.php
@@ -2,9 +2,12 @@
 
 namespace OCA\Recognize\Dav;
 
+use OC\Metadata\IMetadataManager;
 use OCA\Recognize\Db\FaceClusterMapper;
 use OCA\Recognize\Db\FaceDetectionMapper;
 use OCP\Files\IRootFolder;
+use OCP\IPreview;
+use OCP\ITagManager;
 use OCP\IUserSession;
 use Sabre\DAV\Exception\Forbidden;
 use \Sabre\DAVACL\AbstractPrincipalCollection;
@@ -15,13 +18,19 @@ class RootCollection extends AbstractPrincipalCollection {
 	private FaceClusterMapper $faceClusterMapper;
 	private FaceDetectionMapper $faceDetectionMapper;
 	private IRootFolder $rootFolder;
+	private ITagManager $tagManager;
+	private IMetadataManager $metadataManager;
+	private IPreview $previewManager;
 
-	public function __construct(BackendInterface $principalBackend, IUserSession $userSession, FaceClusterMapper $faceClusterMapper, FaceDetectionMapper $faceDetectionMapper, IRootFolder $rootFolder) {
+	public function __construct(BackendInterface $principalBackend, IUserSession $userSession, FaceClusterMapper $faceClusterMapper, FaceDetectionMapper $faceDetectionMapper, IRootFolder $rootFolder, ITagManager $tagManager, IMetadataManager $metadataManager, IPreview $previewManager) {
 		parent::__construct($principalBackend, 'principals/users');
 		$this->userSession = $userSession;
 		$this->faceClusterMapper = $faceClusterMapper;
 		$this->faceDetectionMapper = $faceDetectionMapper;
 		$this->rootFolder = $rootFolder;
+		$this->tagManager = $tagManager;
+		$this->metadataManager = $metadataManager;
+		$this->previewManager = $previewManager;
 	}
 
 	public function getChildForPrincipal(array $principalInfo): RecognizeHome {
@@ -30,7 +39,7 @@ class RootCollection extends AbstractPrincipalCollection {
 		if (is_null($user) || $name !== $user->getUID()) {
 			throw new Forbidden();
 		}
-		return new RecognizeHome($principalInfo, $this->faceClusterMapper, $user, $this->faceDetectionMapper, $this->rootFolder);
+		return new RecognizeHome($principalInfo, $this->faceClusterMapper, $user, $this->faceDetectionMapper, $this->rootFolder, $this->tagManager, $this->metadataManager, $this->previewManager);
 	}
 
 	public function getName() {

--- a/lib/Dav/RootCollection.php
+++ b/lib/Dav/RootCollection.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace OCA\Recognize\Dav;
+
+use OCA\Recognize\Db\FaceClusterMapper;
+use OCA\Recognize\Db\FaceDetectionMapper;
+use OCP\Files\IRootFolder;
+use OCP\IUserSession;
+use Sabre\DAV\Exception\Forbidden;
+use \Sabre\DAVACL\AbstractPrincipalCollection;
+use \Sabre\DAVACL\PrincipalBackend\BackendInterface;
+
+class RootCollection extends AbstractPrincipalCollection {
+	private IUserSession $userSession;
+	private FaceClusterMapper $faceClusterMapper;
+	private FaceDetectionMapper $faceDetectionMapper;
+	private IRootFolder $rootFolder;
+
+	public function __construct(BackendInterface $principalBackend, IUserSession $userSession, FaceClusterMapper $faceClusterMapper, FaceDetectionMapper $faceDetectionMapper, IRootFolder $rootFolder) {
+		parent::__construct($principalBackend, 'principals/users');
+		$this->userSession = $userSession;
+		$this->faceClusterMapper = $faceClusterMapper;
+		$this->faceDetectionMapper = $faceDetectionMapper;
+		$this->rootFolder = $rootFolder;
+	}
+
+	public function getChildForPrincipal(array $principalInfo): RecognizeHome {
+		[, $name] = \Sabre\Uri\split($principalInfo['uri']);
+		$user = $this->userSession->getUser();
+		if (is_null($user) || $name !== $user->getUID()) {
+			throw new Forbidden();
+		}
+		return new RecognizeHome($principalInfo, $this->faceClusterMapper, $user, $this->faceDetectionMapper, $this->rootFolder);
+	}
+
+	public function getName() {
+		return 'recognize';
+	}
+}

--- a/lib/Db/FaceClusterMapper.php
+++ b/lib/Db/FaceClusterMapper.php
@@ -13,6 +13,8 @@ class FaceClusterMapper extends QBMapper {
 	}
 
 	/**
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 * @throws \OCP\DB\Exception
 	 */
 	public function find(int $id): FaceCluster {
@@ -32,6 +34,21 @@ class FaceClusterMapper extends QBMapper {
 			->from('recognize_face_clusters')
 			->where($qb->expr()->eq('user_id', $qb->createPositionalParameter($userId)));
 		return $this->findEntities($qb);
+	}
+
+
+	/**
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 * @throws \OCP\DB\Exception
+	 */
+	public function findByUserAndTitle(string $userId, string $title) : Entity {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select(FaceCluster::$columns)
+			->from('recognize_face_clusters')
+			->where($qb->expr()->eq('user_id', $qb->createPositionalParameter($userId)))
+			->andWhere($qb->expr()->eq('title', $qb->createPositionalParameter($title)));
+		return $this->findEntity($qb);
 	}
 
 	/**

--- a/lib/Db/FaceDetection.php
+++ b/lib/Db/FaceDetection.php
@@ -53,7 +53,7 @@ class FaceDetection extends Entity {
 
 	public function toArray(): array {
 		$array = [];
-		foreach (self::$fields as $field) {
+		foreach (static::$fields as $field) {
 			$array[$field] = $this->{$field};
 		}
 		return $array;

--- a/lib/Db/FaceDetectionMapper.php
+++ b/lib/Db/FaceDetectionMapper.php
@@ -78,6 +78,21 @@ class FaceDetectionMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
+	/**
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 * @throws \OCP\DB\Exception
+	 */
+	public function findByFileIdAndClusterId(int $fileId, int $clusterId) : FaceDetection {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select(FaceDetection::$columns)
+			->from('recognize_face_detections', 'd')
+			->leftJoin('d', 'recognize_face_clusters', 'c', $qb->expr()->eq('d.cluster_id', 'c.id'))
+		->where($qb->expr()->eq('d.file_id', $qb->createPositionalParameter($fileId, IQueryBuilder::PARAM_INT)))
+		->andWhere($qb->expr()->eq('c.id', $qb->createPositionalParameter($clusterId, IQueryBuilder::PARAM_INT)));
+		return $this->findEntity($qb);
+	}
+
 	protected function mapRowToEntity(array $row): Entity {
 		try {
 			return parent::mapRowToEntity($row);

--- a/lib/Db/FaceDetectionMapper.php
+++ b/lib/Db/FaceDetectionMapper.php
@@ -84,7 +84,7 @@ class FaceDetectionMapper extends QBMapper {
 		} catch (\Exception $e) {
 			$entity = FaceDetectionWithTitle::fromRow($row);
 			if ($entity->getTitle() === '') {
-				$entity->setTitle('Person '.$entity->getClusterId());
+				$entity->setTitle($entity->getClusterId());
 			}
 			return $entity;
 		}

--- a/lib/Db/FaceDetectionMapper.php
+++ b/lib/Db/FaceDetectionMapper.php
@@ -2,6 +2,7 @@
 
 namespace OCA\Recognize\Db;
 
+use OCP\AppFramework\Db\Entity;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -66,5 +67,26 @@ class FaceDetectionMapper extends QBMapper {
 	public function assocWithCluster(FaceDetection $faceDetection, FaceCluster $faceCluster) {
 		$faceDetection->setClusterId($faceCluster->getId());
 		$this->update($faceDetection);
+	}
+
+	public function findByFileIdWithTitle(int $fileId) {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select(array_merge(array_map(fn ($col) => 'd.'.$col, FaceDetection::$columns), ['c.title']))
+			->from('recognize_face_detections', 'd')
+			->where($qb->expr()->eq('file_id', $qb->createPositionalParameter($fileId, IQueryBuilder::PARAM_INT)))
+			->leftJoin('d', 'recognize_face_clusters', 'c', $qb->expr()->eq('d.cluster_id', 'c.id'));
+		return $this->findEntities($qb);
+	}
+
+	protected function mapRowToEntity(array $row): Entity {
+		try {
+			return parent::mapRowToEntity($row);
+		} catch (\Exception $e) {
+			$entity = FaceDetectionWithTitle::fromRow($row);
+			if ($entity->getTitle() === '') {
+				$entity->setTitle('Person '.$entity->getClusterId());
+			}
+			return $entity;
+		}
 	}
 }

--- a/lib/Db/FaceDetectionWithTitle.php
+++ b/lib/Db/FaceDetectionWithTitle.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OCA\Recognize\Db;
+
+/**
+ * @method string getTitle()
+ * @method setTitle(string $title)
+ */
+class FaceDetectionWithTitle extends FaceDetection {
+	protected $title;
+
+	public static $columns = ['id', 'user_id', 'file_id', 'x', 'y', 'height', 'width', 'vector', 'cluster_id', 'title'];
+	public static $fields = ['id', 'userId', 'fileId', 'x', 'y', 'height', 'width', 'vector', 'clusterId', 'title'];
+
+	public function __construct() {
+		parent::__construct();
+		$this->addType('title', 'string');
+	}
+}

--- a/lib/Service/FaceClusterAnalyzer.php
+++ b/lib/Service/FaceClusterAnalyzer.php
@@ -13,7 +13,7 @@ use Rubix\ML\Kernels\Distance\Euclidean;
 
 class FaceClusterAnalyzer {
 	public const MIN_CLUSTER_DENSITY = 3;
-	public const MAX_INNER_CLUSTER_RADIUS = 0.35;
+	public const MAX_INNER_CLUSTER_RADIUS = 0.4;
 
 	private FaceDetectionMapper $faceDetections;
 	private FaceClusterMapper $faceClusters;


### PR DESCRIPTION
URL schema is:
```
/dav/recognize/<user>/faces/<person-name>/<id>-<filename>
```

Face clusters can be renamed using MOVE, files can be assigned to a different cluster using MOVE, both can be removed using DELETE.

- [x] Add PROPFIND handler for face position in the picture, maybe?

Based on https://github.com/nextcloud/photos/pull/1146