### PR TITLE
Fix label padding in admin settings

### DIFF
--- a/src/components/ViewAdmin.vue
+++ b/src/components/ViewAdmin.vue
@@ -392,6 +392,7 @@ figure[class^='icon-'] {
 
 #recognize label > * {
 	padding: 8px 0;
+	padding-left: 6px;
 }
 
 #recognize input[type=text], #recognize input[type=password] {


### PR DESCRIPTION
Current:
![image](https://user-images.githubusercontent.com/10717998/192367870-72d214fc-90a9-4405-b21a-be4ac28cae64.png)

After Fix:
![image](https://user-images.githubusercontent.com/10717998/192367932-4fa13db2-5b00-4d8d-8797-3d8aa3e8738e.png)


Signed-off-by: MeIchthys <10717998+meichthys@users.noreply.github.com>