### PR TITLE
Exclude l10n and models from GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+l10n/** linguist-vendored
+models/** linguist-vendored


### PR DESCRIPTION
I don't know why, but this bothers me

Signed-off-by: Varun Patil <varunpatil@ucla.edu>