### PR TITLE
Stabilize face clustering across manual cluster edits

### DIFF
--- a/lib/Db/FaceDetection.php
+++ b/lib/Db/FaceDetection.php
@@ -12,18 +12,20 @@ use OCP\AppFramework\Db\Entity;
  * @method setFileId(int $fileId)
  * @method setUserId(string $userId)
  * @method string getUserId()
- * @method int getX()
- * @method int getY()
- * @method int getHeight()
- * @method int getWidth()
+ * @method float getX()
+ * @method float getY()
+ * @method float getHeight()
+ * @method float getWidth()
  * @method array getVector()
  * @method setVector(array $vector)
- * @method setX(int $x)
- * @method setY(int $y)
+ * @method setX(float $x)
+ * @method setY(float $y)
  * @method setHeight(int $height)
  * @method setWidth(int $width)
  * @method setClusterId(int|null $clusterId)
  * @method int getClusterId()
+ * @method float getThreshold()
+ *  @method setThreshold(float $threshold)
  */
 class FaceDetection extends Entity {
 	protected $fileId;
@@ -34,9 +36,10 @@ class FaceDetection extends Entity {
 	protected $width;
 	protected $vector;
 	protected $clusterId;
+	protected $threshold;
 
-	public static $columns = ['id', 'user_id', 'file_id', 'x', 'y', 'height', 'width', 'vector', 'cluster_id'];
-	public static $fields = ['id', 'userId', 'fileId', 'x', 'y', 'height', 'width', 'vector', 'clusterId'];
+	public static $columns = ['id', 'user_id', 'file_id', 'x', 'y', 'height', 'width', 'vector', 'cluster_id', 'threshold'];
+	public static $fields = ['id', 'userId', 'fileId', 'x', 'y', 'height', 'width', 'vector', 'clusterId', 'threshold'];
 
 	public function __construct() {
 		// add types in constructor
@@ -49,6 +52,7 @@ class FaceDetection extends Entity {
 		$this->addType('width', 'float');
 		$this->addType('vector', 'json');
 		$this->addType('clusterId', 'int');
+		$this->addType('threshold', 'float');
 	}
 
 	public function toArray(): array {

--- a/lib/Migration/Version003001000Date20221017094721.php
+++ b/lib/Migration/Version003001000Date20221017094721.php
@@ -22,7 +22,7 @@ class Version003001000Date20221017094721 extends SimpleMigrationStep {
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 * @param array $options
 	 *
-	 * @return ISchemaWrapper
+	 * @return ?ISchemaWrapper
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
 		/** @var ISchemaWrapper $schema */

--- a/lib/Migration/Version003001000Date20221017094721.php
+++ b/lib/Migration/Version003001000Date20221017094721.php
@@ -22,16 +22,6 @@ class Version003001000Date20221017094721 extends SimpleMigrationStep {
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
 	 * @param array $options
 	 *
-	 * @return void
-	 */
-	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
-	}
-
-	/**
-	 * @param IOutput $output
-	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
-	 *
 	 * @return ISchemaWrapper
 	 */
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
@@ -44,17 +34,7 @@ class Version003001000Date20221017094721 extends SimpleMigrationStep {
 				'notnull' => true,
 				'default' => 0.0,
 			]);
+			return $schema;
 		}
-		return $schema;
-	}
-
-	/**
-	 * @param IOutput $output
-	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
-	 * @param array $options
-	 *
-	 * @return void
-	 */
-	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
 	}
 }

--- a/lib/Migration/Version003001000Date20221017094721.php
+++ b/lib/Migration/Version003001000Date20221017094721.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright (c) 2020. The Nextcloud Bookmarks contributors.
+ *
+ * This file is licensed under the Affero General Public License version 3 or later. See the COPYING file.
+ */
+
+namespace OCA\Recognize\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version003001000Date20221017094721 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return void
+	 */
+	public function preSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('recognize_face_detections')) {
+			$table = $schema->getTable('recognize_face_detections');
+			$table->addColumn('threshold', Types::FLOAT, [
+				'notnull' => true,
+				'default' => 0.0,
+			]);
+		}
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 *
+	 * @return void
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+	}
+}

--- a/lib/Migration/Version003001000Date20221017094721.php
+++ b/lib/Migration/Version003001000Date20221017094721.php
@@ -36,5 +36,6 @@ class Version003001000Date20221017094721 extends SimpleMigrationStep {
 			]);
 			return $schema;
 		}
+		return null;
 	}
 }

--- a/lib/Service/FaceClusterAnalyzer.php
+++ b/lib/Service/FaceClusterAnalyzer.php
@@ -66,6 +66,7 @@ class FaceClusterAnalyzer {
 			$alreadyClustered = array_values(array_filter($detectionsWithClusters, function ($item) : bool {
 				return count($item[1]) >= 1;
 			}));
+
 			$notYetClustered = array_filter($detectionsWithClusters, function ($item) : bool {
 				return count($item[1]) === 0;
 			});
@@ -75,19 +76,22 @@ class FaceClusterAnalyzer {
 					return $item[1][0]->getId();
 				}, $alreadyClustered));
 				if (count($uniqueOldClusterIds) === 1) {
-					// There's only one old cluster for all already clustered detections in this new cluster, so we'll use that
+					// There's only one old cluster for all already clustered detections
+					// in this new cluster, so we'll use that
 					$cluster = $alreadyClustered[0][1][0];
+					$clusterCentroid = self::calculateCentroidOfDetections(array_map(fn ($item) => $item[0], $alreadyClustered));
 				} else {
-					// This should be an edge case and not happen often:
 					// This new cluster contains detections from different existing clusters
-					// we need a completely new cluster
+					// we need a completely new cluster for the not yet assigned detections
 					$cluster = new FaceCluster();
 					$cluster->setTitle('');
 					$cluster->setUserId($userId);
 					$cluster = $this->faceClusters->insert($cluster);
+					$clusterCentroid = self::calculateCentroidOfDetections(array_map(fn ($item) => $item[0], $notYetClustered));
 				}
 			} else {
-				// we need a completely new cluster
+				// we need a completely new cluster since none of the detections
+				// in this new cluster have been assigned
 				$cluster = new FaceCluster();
 				$cluster->setTitle('');
 				$cluster->setUserId($userId);
@@ -96,9 +100,22 @@ class FaceClusterAnalyzer {
 				 * @var FaceCluster $cluster
 				 */
 				$cluster = $this->faceClusters->insert($cluster);
+
+				$clusterCentroid = self::calculateCentroidOfDetections($clusterDetections);
 			}
 			foreach ($notYetClustered as $item) {
+				/** @var FaceDetection $detection */
 				$detection = $item[0];
+				$distance = new Euclidean();
+				if ($detection->getThreshold() !== 0.0) {
+					// If a threshold is set for this detection and its vector is farther away from the centroid
+					// than the threshold, skip assigning this detection to the cluster
+					$distanceValue = $distance->compute($clusterCentroid, $detection->getVector());
+					if ($distanceValue >= $detection->getThreshold()) {
+						continue;
+					}
+				}
+
 				$this->faceDetections->assocWithCluster($detection, $cluster);
 			}
 		}
@@ -131,7 +148,7 @@ class FaceClusterAnalyzer {
 				continue;
 			}
 
-			$centroid = $this->calculateCentroidOfDetections($detections);
+			$centroid = self::calculateCentroidOfDetections($detections);
 
 			foreach ($filesWithDuplicateFaces as $fileDetections) {
 				$detectionsByDistance = [];
@@ -157,7 +174,7 @@ class FaceClusterAnalyzer {
 	 * @param FaceDetection[] $detections
 	 * @return array<float>
 	 */
-	private function calculateCentroidOfDetections(array $detections): array {
+	public static function calculateCentroidOfDetections(array $detections): array {
 		// init 128 dimensional vector
 		$sum = [];
 		for ($i = 0; $i < 128; $i++) {

--- a/lib/Service/FaceClusterAnalyzer.php
+++ b/lib/Service/FaceClusterAnalyzer.php
@@ -107,7 +107,7 @@ class FaceClusterAnalyzer {
 				/** @var FaceDetection $detection */
 				$detection = $item[0];
 				$distance = new Euclidean();
-				if ($detection->getThreshold() !== 0.0) {
+				if ($detection->getThreshold() > 0.0) {
 					// If a threshold is set for this detection and its vector is farther away from the centroid
 					// than the threshold, skip assigning this detection to the cluster
 					$distanceValue = $distance->compute($clusterCentroid, $detection->getVector());


### PR DESCRIPTION
Currently when a user manually removes a detection from a cluster, it will likely be readded on the next clustering job, because the clustering algorithm doesn't care. This PR introduces a linking threshold for detections, which by default is 0 for *free to go*, but once you delete a detection from a cluster, the threshold is set on that detection, which will prevent it from being linked to clusters with the same or a higher distance to the cluster centroid as the one it was deleted from. Essentially, we make sure that the clustering algorithm really has found a better-fitting cluster for this detection the next time around.

fixes #391 