### PR TITLE
Update ClusteringFaceClassifier.php

### DIFF
--- a/lib/Classifiers/Images/ClusteringFaceClassifier.php
+++ b/lib/Classifiers/Images/ClusteringFaceClassifier.php
@@ -97,7 +97,7 @@ class ClusteringFaceClassifier extends Classifier {
 				foreach ($userIds as $userId) {
 					$faceDetection->setUserId($userId);
 					try {
-						$this->faceDetections->insert($faceDetection);
+						$this->faceDetections->insertOrUpdate($faceDetection);
 					} catch (Exception $e) {
 						$this->logger->error('Could not store face detection in database', ['exception' => $e]);
 						continue;

--- a/lib/Classifiers/Images/ClusteringFaceClassifier.php
+++ b/lib/Classifiers/Images/ClusteringFaceClassifier.php
@@ -97,12 +97,23 @@ class ClusteringFaceClassifier extends Classifier {
 				foreach ($userIds as $userId) {
 					$faceDetection->setUserId($userId);
 					try {
-						$this->faceDetections->insertOrUpdate($faceDetection);
+						$this->faceDetections->insert($faceDetection);
 					} catch (Exception $e) {
 						$this->logger->error('Could not store face detection in database', ['exception' => $e]);
 						continue;
 					}
 					$usersToCluster[] = $userId;
+
+					if ( count($userIds) >1 ) {
+						// prepare autoincrement-safe re-use of $faceDetection-entity
+						$faceDetection->resetUpdatedFields();
+						$faceDetection->markFieldUpdated('x');
+						$faceDetection->markFieldUpdated('y');
+						$faceDetection->markFieldUpdated('width');
+						$faceDetection->markFieldUpdated('height');
+						$faceDetection->markFieldUpdated('vector');
+						$faceDetection->markFieldUpdated('fileId');
+					}
 				}
 				$this->config->setAppValue('recognize', self::MODEL_NAME.'.status', 'true');
 				$this->config->setAppValue('recognize', self::MODEL_NAME.'.lastFile', time());

--- a/lib/Classifiers/Images/ClusteringFaceClassifier.php
+++ b/lib/Classifiers/Images/ClusteringFaceClassifier.php
@@ -104,7 +104,7 @@ class ClusteringFaceClassifier extends Classifier {
 					}
 					$usersToCluster[] = $userId;
 
-					if ( count($userIds) >1 ) {
+					if (count($userIds) > 1) {
 						// prepare autoincrement-safe re-use of $faceDetection-entity
 						$faceDetection->resetUpdatedFields();
 						$faceDetection->markFieldUpdated('x');

--- a/lib/Db/FaceDetection.php
+++ b/lib/Db/FaceDetection.php
@@ -62,4 +62,8 @@ class FaceDetection extends Entity {
 		}
 		return $array;
 	}
+
+	public function markFieldUpdated($attribute) {
+		parent::markFieldUpdated($attribute);
+	}
 }


### PR DESCRIPTION
Fix of #417: Constraint violation in ClusteringFaceClassifier.php -> classify

"Could not store face detection in database","userAgent":"--","version":"25.0.0.18","exception":{"Exception":"OC\\DB\\Exceptions\\DbalException","Message":"An exception occurred while executing a query: SQLSTATE[23505]: Unique violation: 7 ERROR:  duplicate key value violates unique constraint \"oc_recognize_face_detections_pkey\"\nDETAIL:  Key (id)=(xxx) already exists.","Code":7

Signed-off-by: umgfoin <umgfoin@users.noreply.github.com>