### PR TITLE
Use more compatible file to check for musl

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -109,7 +109,7 @@ class AdminController extends Controller {
 
 	public function musl(): JSONResponse {
 		try {
-			exec('ldd /bin/ls' . ' 2>&1', $output, $returnCode);
+			exec('ldd /bin/sh' . ' 2>&1', $output, $returnCode);
 		} catch (\Throwable $e) {
 			return new JSONResponse(['musl' => null]);
 		}


### PR DESCRIPTION
This should work on all existing distros and in addition works on NixOS.

Closes #428

Signed-off-by: Sandro <sandro.jaeckel@gmail.com>