### PR TITLE
Disable timeout for downloads on cli usage

### DIFF
--- a/lib/Service/DownloadModelsService.php
+++ b/lib/Service/DownloadModelsService.php
@@ -10,9 +10,11 @@ use RecursiveIteratorIterator;
 
 class DownloadModelsService {
 	private IClientService $clientService;
+	private bool $isCLI;
 
-	public function __construct(IClientService $clientService) {
+	public function __construct(IClientService $clientService, bool $isCLI) {
 		$this->clientService = $clientService;
+		$this->isCLI = $isCLI;
 	}
 
 	/**
@@ -38,7 +40,8 @@ class DownloadModelsService {
 
 		$archiveUrl = $this->getArchiveUrl($this->getNeededArchiveRef());
 		$archivePath = __DIR__ . '/../../models.tar.gz';
-		$this->clientService->newClient()->get($archiveUrl, ['sink' => $archivePath, 'timeout' => 480]);
+		$timeout = $this->isCLI ? 0 : 480;
+		$this->clientService->newClient()->get($archiveUrl, ['sink' => $archivePath, 'timeout' => $timeout]);
 		$tarManager = new TAR($archivePath);
 		$tarFiles = $tarManager->getFiles();
 		$mainFolder = $tarFiles[0];


### PR DESCRIPTION
Adjust the timeout handling to how app downloads are already handled by the server.

https://github.com/nextcloud/server/blob/0efd6d995037bc34de714024f137fecdbdc50a69/lib/private/Installer.php#L293

Contributes to https://github.com/nextcloud/recognize/issues/329#issuecomment-1301163115
