### PR TITLE
dav: replace fileid in name with detectionid

### DIFF
--- a/lib/Dav/Faces/FacePhoto.php
+++ b/lib/Dav/Faces/FacePhoto.php
@@ -46,7 +46,8 @@ class FacePhoto implements IFile {
 	 */
 	public function getName() {
 		$file = $this->getFile();
-		return $file->getId() . '-' . $file->getName();
+		$detection = $this->getFaceDetection();
+		return $detection->getId() . '-' . $file->getName();
 	}
 
 	/**

--- a/lib/Dav/Faces/FaceRoot.php
+++ b/lib/Dav/Faces/FaceRoot.php
@@ -104,9 +104,9 @@ class FaceRoot implements ICollection, IMoveTarget {
 			}
 			throw new NotFound("$name not found");
 		}
-		[$fileId,] = explode('-', $name);
+		[$detectionId,] = explode('-', $name);
 		try {
-			$detection = $this->detectionMapper->findByFileIdAndClusterId((int)$fileId, $this->cluster->getId());
+			$detection = $this->detectionMapper->find((int)$detectionId);
 		} catch (DoesNotExistException $e) {
 			throw new NotFound();
 		}

--- a/lib/Db/FaceDetectionMapper.php
+++ b/lib/Db/FaceDetectionMapper.php
@@ -153,22 +153,6 @@ class FaceDetectionMapper extends QBMapper {
 	}
 
 	/**
-	 * @throws \OCP\AppFramework\Db\DoesNotExistException
-	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
-	 * @throws \OCP\DB\Exception
-	 */
-	public function findByFileIdAndClusterId(int $fileId, int $clusterId) : FaceDetection {
-		$qb = $this->db->getQueryBuilder();
-		$qb->select(array_map(fn ($c) => 'd.'.$c, FaceDetection::$columns))
-			->from('recognize_face_detections', 'd')
-			->setMaxResults(1)
-			->leftJoin('d', 'recognize_face_clusters', 'c', $qb->expr()->eq('d.cluster_id', 'c.id'))
-			->where($qb->expr()->eq('d.file_id', $qb->createPositionalParameter($fileId, IQueryBuilder::PARAM_INT)))
-			->andWhere($qb->expr()->eq('c.id', $qb->createPositionalParameter($clusterId, IQueryBuilder::PARAM_INT)));
-		return $this->findEntity($qb);
-	}
-
-	/**
 	 * @return list<string>
 	 * @throws \OCP\DB\Exception
 	 */


### PR DESCRIPTION
This allows you to unambiguously move detections from one cluster to another instead of files. As a result, if two detections from the same file end up in one cluster, we don't have any funny behavior.

Note that it is perfectly possible to have multiple detections for the same file in the same cluster, e.g. when a person is present multiple times inside a single image. In this case, we need to do de-duplication somewhere, but this is currently unimplemented anyway.

Notes:
1. The current behavior with multiple detections in one cluster seems random.
2. This also opens up the possibility of having a "Unclustered" cluster. This will in all probability contain multiple detections from the same file. Then you can move individual detections from this "null" cluster to an identified cluster.