### PR TITLE
dav: allow creating clusters

### DIFF
--- a/lib/Dav/Faces/FacesHome.php
+++ b/lib/Dav/Faces/FacesHome.php
@@ -52,7 +52,10 @@ class FacesHome implements ICollection {
 	}
 
 	public function createDirectory($name) {
-		throw new Forbidden('Not allowed to create directories in this folder');
+		$entity = new FaceCluster();
+		$entity->setUserId($this->user->getUID());
+		$entity->setTitle($name);
+		$this->faceClusterMapper->insert($entity);
 	}
 
 	public function createFile($name, $data = null) {


### PR DESCRIPTION
Fixes #443 

The created cluster is not visible directly in the listing (because there's nothing in it), but it still exists. So now the user can move detections into it with the DAV API.