### PR TITLE
Fix edge pruning under minClusterSeparation

### DIFF
--- a/lib/Clustering/MstClusterer.php
+++ b/lib/Clustering/MstClusterer.php
@@ -131,13 +131,22 @@ class MstClusterer {
 				[$childClusterEdges2, $childClusterVerticesToEdges2] = $this->getChildClusterComponents($vertexConnectedFrom);
 
 				if ($edgeLength < $this->minClusterSeparation) {
+					$prunedEdges = [];
 					if (count($childClusterEdges1) > count($childClusterEdges2)) {
 						$this->remainingEdges = $childClusterEdges1;
 						$this->mapVerticesToEdges = $childClusterVerticesToEdges1;
+						$prunedEdges = $childClusterEdges2;
 					} else {
 						$this->remainingEdges = $childClusterEdges2;
 						$this->mapVerticesToEdges = $childClusterVerticesToEdges2;
+						$prunedEdges = $childClusterEdges1;
 					}
+					
+					// Set the final lambda for the pruned edges:
+					foreach (array_keys($prunedEdges) as $edgeKey) {
+						$this->edges[$edgeKey]['finalLambda'] = $currentLambda;
+					}
+					
 					continue;
 				}
 


### PR DESCRIPTION
Fix a bug in the pruning of edges when the current edge length is under $minClusterSeparation