### PR TITLE
Make 'nice' check cross-platform

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -201,7 +201,7 @@ class AdminController extends Controller {
 		}
 
 		try {
-			exec($nice_path . ' --version' . ' 2>&1', $output, $returnCode);
+			exec($nice_path . ' true' . ' 2>&1', $output, $returnCode);
 		} catch (\Throwable $e) {
 			return new JSONResponse(['nice' => false]);
 		}


### PR DESCRIPTION
`nice(1)` has no `--version` option in non-GNU installations (FreeBSD, in this case). Rather do a `nice true` to test its function.