### PR TITLE
Update AdminController.php platform check

### DIFF
--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -157,18 +157,7 @@ class AdminController extends Controller {
 	}
 
 	public function platform(): JSONResponse {
-		try {
-			exec('lscpu --json' . ' 2>&1', $output, $returnCode);
-		} catch (\Throwable $e) {
-			return new JSONResponse(['platform' => null]);
-		}
-
-		if ($returnCode !== 0) {
-			return new JSONResponse(['platform' => null]);
-		}
-
-		$lscpu = \json_decode(trim(implode("\n", $output)), true);
-		return new JSONResponse(['platform' => $lscpu['lscpu'][0]['data']]);
+		return new JSONResponse(['platform' => php_uname('m')]);
 	}
 
 	public function musl(): JSONResponse {


### PR DESCRIPTION
Updated platform() checking function to use PHP's in-built [php_uname()](https://www.php.net/manual/en/function.php-uname.php) function to return machine type (eg. x86_64).

This change was made to fix platform checking when installed under the NextCloud Snap envrionment (see  #1120). This code works on my deployment - Recognize installed from web UI on NextCloud Snap, running within a Proxmox virtual machine. Unfortunately I don't have the time or resources to check under other installs/architectures.