### PR TITLE
lib: allow webp in IMAGE_FORMATS

### DIFF
--- a/lib/Constants.php
+++ b/lib/Constants.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 namespace OCA\Recognize;
 
 class Constants {
-	public const IMAGE_FORMATS = ['image/jpeg', 'image/png', 'image/bmp', 'image/heic', 'image/heif', 'image/tiff'];
+	public const IMAGE_FORMATS = ['image/jpeg', 'image/png', 'image/bmp', 'image/heic', 'image/heif', 'image/tiff', 'image/webp'];
 	public const AUDIO_FORMATS = ['audio/mpeg', 'audio/mp4', 'audio/ogg', 'audio/vnd.wav', 'audio/flac'];
 	public const VIDEO_FORMATS = ['image/gif', 'video/mp4', 'video/MP2T', 'video/x-msvideo', 'video/x-ms-wmv', 'video/quicktime', 'video/ogg', 'video/mpeg', 'video/webm', 'video/x-matroska'];
 	public const DIRECTORY_FORMATS = ['httpd/unix-directory'];


### PR DESCRIPTION
My webp images weren't being tagged and simply adding the relevant mime type in IMAGE_FORMATS appears to be enough.