### PR TITLE
(U) Fix to ClusterFacesJob.php in Instances with Numeric User IDs

### DIFF
--- a/lib/BackgroundJobs/ClusterFacesJob.php
+++ b/lib/BackgroundJobs/ClusterFacesJob.php
@@ -37,7 +37,7 @@ class ClusterFacesJob extends QueuedJob {
 	 */
 	protected function run($argument) {
 		/** @var string $userId */
-		$userId = $argument['userId'];
+		$userId = (string) $argument['userId'];
 		try {
 			$this->clusterAnalyzer->calculateClusters($userId, self::BATCH_SIZE);
 		} catch (\JsonException|Exception $e) {


### PR DESCRIPTION
On my instance, as soon as I added profile pictures for my users, I started receiving the following log error message:

`TypeError
OCA\Recognize\Service\FaceClusterAnalyzer::calculateClusters(): Argument #1 ($userId) must be of type string, int given, called in /var/www/html/custom_apps/recognize/lib/BackgroundJobs/ClusterFacesJob.php on line 43`

When I made this change locally, the error messages stopped being printed, and I was able to manually kick off face clustering. Not sure if this is comprehensive as I'm not too sure exactly how this all works.  My status 12 hours later currently reads: `24 faces left to cluster, Last clustering run: 14 hours ago` Not sure why it isn't done, but I haven't seen any new errors logged.

Don't have the time to do things too pretty. Someone can either merge this, modify it, or copy it and apply it to their instance if they have the same issue.

Regards,
     ~ Joey