### PR TITLE
docs: remove suspicious_login conflict warning

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -71,7 +71,6 @@ Requirements:
   - Processor: x86 64-bit, arm64, armv7l (no AVX needed)
   - System with glibc or musl (incl. Alpine linux and thus also the official Nextcloud Docker container and also Nextcloud AIO)
 - ~4GB of free RAM (if you're cutting it close, make sure you have some swap available)
-- This app is currently incompatible with the *Suspicious Login* app due to a dependency conflict (ie. you can only have one of the two installed)
 
 The app does not send any sensitive data to cloud providers or similar services. All processing is done on your Nextcloud machine, using Tensorflow.js running in Node.js.
 


### PR DESCRIPTION
According to https://github.com/nextcloud/recognize/issues/1051, the Recognize app is no longer incompatible with Suspicious Login since v6.1.0, however the app info in the Nextcloud app store still says that this is the case. This PR removes this warning.