### PR TITLE
fix: Don't error if movinet.enabled=false and wasm=true

### DIFF
--- a/lib/Command/Classify.php
+++ b/lib/Command/Classify.php
@@ -147,6 +147,9 @@ final class Classify extends Command {
 				}
 
 				foreach ($this->classifiers as $modelName => $classifier) {
+					if (!in_array($modelName, $models)) {
+						continue;
+					}
 					try {
 						$classifier->setMaxExecutionTime(0);
 						$classifier->classify($queues[$modelName]);


### PR DESCRIPTION
fixes #1257