### PR TITLE
[CI]: Add custom CI timeout to detect stuck jobs earlier

### DIFF
--- a/.github/workflows/full-run-test.yml
+++ b/.github/workflows/full-run-test.yml
@@ -55,6 +55,8 @@ jobs:
       MYSQL_PORT: 4444
       PGSQL_PORT: 4445
 
+    timeout-minutes: 36 # max + 3*std over the last 212 successful runs
+
     services:
       mysql:
         image: mariadb:10.5


### PR DESCRIPTION
### Change Summary
Added custom timeout for `php` job of the `Classify command test` workflow based on historical data that could lead to resource savings and faster CI for the project.

### More details
Over the last 212 successful runs, the `php` job has a maximum runtime duration of 24 minutes (mean=11, std=4) across all matrix combinations.

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/nextcloud/recognize/actions/runs/14940628082/job/41977061290) job run, that failed after 6 hours.

The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail after GitHub's timeout of 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 36 minutes` where `max` and `std` (standard deviation) are derived from the history of 212 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.

Note that the timeout applies to all the matrix jobs, and not to their sum, overriding the default 6-hour timeout of github.
<details>
<summary>Click here to see all the recently timed-out runs.</summary>

10-May-2025 => [timed-out-run](https://github.com/nextcloud/recognize/actions/runs/14940628082/job/41977061290)
25-Mar-2025 => [timed-out run](https://github.com/nextcloud/recognize/actions/runs/14061177875/job/39372085938)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this and for your contribution to open-source software in general.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)
konstantinos.kitsios@uzh.ch