### PR TITLE
feat: Add ExApp / dedicated-device classification backend

### DIFF
--- a/.github/workflows/exapp-appstore-build-publish.yml
+++ b/.github/workflows/exapp-appstore-build-publish.yml
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Packages the Recognize ExApp manifest and uploads it to the Nextcloud App Store.
+# The Docker image itself is built and pushed by exapp-publish-docker.yml; the App
+# Store only stores the manifest (appinfo/info.xml) and points at the registry.
+
+name: Build and publish Recognize ExApp
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  APP_ID: recognize_exapp
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'nextcloud' }}
+    steps:
+      - name: Check actor permission
+        uses: skjnldsv/check-actor-permission@v3.0
+        with:
+          require: write
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          path: recognize
+
+      - name: Stage ExApp for packaging
+        run: cp -r recognize/exapp "$APP_ID"
+
+      - name: Get app version number
+        id: app-version
+        uses: skjnldsv/xpath-action@v1.0.0
+        with:
+          filename: ${{ env.APP_ID }}/appinfo/info.xml
+          expression: "//info//version/text()"
+
+      - name: Get appinfo data
+        id: appinfo
+        uses: skjnldsv/xpath-action@v1.0.0
+        with:
+          filename: ${{ env.APP_ID }}/appinfo/info.xml
+          expression: "//info//dependencies//nextcloud/@min-version"
+
+      - name: Install Krankerl
+        run: |
+          wget -q https://github.com/ChristophWurst/krankerl/releases/download/v0.14.0/krankerl_0.14.0_amd64.deb
+          sudo dpkg -i krankerl_0.14.0_amd64.deb
+
+      - name: Package ${{ env.APP_ID }} with krankerl
+        run: |
+          cd "$APP_ID"
+          krankerl package
+
+      - name: Checkout server
+        continue-on-error: true
+        id: server-checkout
+        run: |
+          NCVERSION='${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}'
+          wget --quiet "https://download.nextcloud.com/server/releases/latest-$NCVERSION.zip"
+          unzip "latest-$NCVERSION.zip"
+
+      - name: Checkout server master fallback
+        uses: actions/checkout@v4
+        if: ${{ steps.server-checkout.outcome != 'success' }}
+        with:
+          persist-credentials: false
+          submodules: true
+          repository: nextcloud/server
+          path: nextcloud
+
+      - name: Sign app
+        run: |
+          cd "$APP_ID/build/artifacts"
+          tar -xvf "$APP_ID.tar.gz"
+          cd ../../../
+          echo '${{ secrets.APP_PRIVATE_KEY }}' > "$APP_ID.key"
+          wget --quiet "https://github.com/nextcloud/app-certificate-requests/raw/master/$APP_ID/$APP_ID.crt"
+          php nextcloud/occ integrity:sign-app --privateKey="$APP_ID.key" --certificate="$APP_ID.crt" --path="$APP_ID/build/artifacts/$APP_ID"
+          cd "$APP_ID/build/artifacts"
+          tar -zcvf "$APP_ID.tar.gz" "$APP_ID"
+
+      - name: Attach tarball to github release
+        uses: svenstaro/upload-release-action@v2
+        id: attach_to_release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ env.APP_ID }}/build/artifacts/${{ env.APP_ID }}.tar.gz
+          asset_name: ${{ env.APP_ID }}-${{ github.ref_name }}.tar.gz
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: Upload app to Nextcloud appstore
+        uses: nextcloud-releases/nextcloud-appstore-push-action@v1.0.3
+        with:
+          app_name: ${{ env.APP_ID }}
+          appstore_token: ${{ secrets.APPSTORE_TOKEN }}
+          download_url: ${{ steps.attach_to_release.outputs.browser_download_url }}
+          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/exapp-publish-docker.yml
+++ b/.github/workflows/exapp-publish-docker.yml
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Publish Recognize ExApp image
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  push_to_registry:
+    name: Build and push ExApp image
+    runs-on: ubuntu-22.04
+    if: ${{ github.repository_owner == 'nextcloud' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install xmlstarlet
+        run: sudo apt-get update && sudo apt-get install -y xmlstarlet
+
+      - name: Extract version from manifest
+        id: extract_version
+        run: |
+          VERSION=$(xmlstarlet sel -t -v "//image-tag" exapp/appinfo/info.xml)
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Extracted version: $VERSION"
+
+      - name: Build and push CPU image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: ./exapp
+          platforms: linux/amd64
+          build-args: |
+            BUILD_TYPE=cpu
+            RECOGNIZE_REF=v${{ env.VERSION }}
+          tags: |
+            ghcr.io/nextcloud/recognize_exapp:${{ env.VERSION }}
+            ghcr.io/nextcloud/recognize_exapp:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* feat: Optionally offload classification to an External App (ExApp) backend, so the machine learning inference can run on a different, more powerful machine — optionally with GPU support ([#73](https://github.com/nextcloud/recognize/issues/73)). The "Recognize classification backend" ExApp is installable from the Nextcloud App Store / External Apps page (requires AppAPI). Select the backend under Admin settings → Recognize → Classification backend. The ExApp sources, manifest and release workflows live in `exapp/`.
+
 ## [12.0.0] - 2026-04-07
 
 ### Breaking changes

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -34,6 +34,7 @@ return [
 		['name' => 'admin#nice', 'url' => '/admin/nice', 'verb' => 'GET'],
 		['name' => 'admin#ffmpeg', 'url' => '/admin/ffmpeg', 'verb' => 'GET'],
 		['name' => 'admin#nodejs', 'url' => '/admin/nodejs', 'verb' => 'GET'],
+		['name' => 'admin#exapp', 'url' => '/admin/exapp', 'verb' => 'GET'],
 		['name' => 'admin#libtensorflow', 'url' => '/admin/libtensorflow', 'verb' => 'GET'],
 		['name' => 'admin#wasmtensorflow', 'url' => '/admin/wasmtensorflow', 'verb' => 'GET'],
 		['name' => 'admin#gputensorflow', 'url' => '/admin/gputensorflow', 'verb' => 'GET'],

--- a/exapp/.nextcloudignore
+++ b/exapp/.nextcloudignore
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+.git
+.github
+.gitignore
+/.nextcloudignore
+/build
+/Dockerfile
+/Makefile
+/krankerl.toml
+/server.js
+/node_modules
+/src

--- a/exapp/Dockerfile
+++ b/exapp/Dockerfile
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Recognize ExApp classification backend.
+#
+# This image is self-contained: it fetches the matching recognize sources
+# (classifier scripts + assets) at build time, so it can be built straight from
+# this directory (`context: ./exapp`) as the Nextcloud App Store / CI expects.
+#
+# BUILD_TYPE selects the Tensorflow backend:
+#   cpu (default) → node:20 base, @tensorflow/tfjs-node
+#   gpu           → CUDA base image, @tensorflow/tfjs-node-gpu
+#
+#   docker build -t recognize_exapp:latest .
+#   docker build --build-arg BUILD_TYPE=gpu -t recognize_exapp:latest-gpu .
+
+ARG BUILD_TYPE=cpu
+
+###############################################################################
+# Base images
+###############################################################################
+FROM node:20-bookworm-slim AS base-cpu
+ENV RECOGNIZE_GPU=false
+# Build tools for native node modules (@tensorflow/tfjs-node postinstall).
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends python3 make g++ \
+	&& rm -rf /var/lib/apt/lists/*
+
+FROM nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04 AS base-gpu
+ENV RECOGNIZE_GPU=true
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends curl ca-certificates gnupg python3 make g++ \
+	&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+	&& apt-get install -y --no-install-recommends nodejs \
+	&& rm -rf /var/lib/apt/lists/*
+
+###############################################################################
+# Final image
+###############################################################################
+# hadolint ignore=DL3006
+FROM base-${BUILD_TYPE}
+
+# The recognize git ref to pull the classifier sources from. Defaults to the
+# tag matching this ExApp's version; CI overrides it to the exact release tag.
+ARG RECOGNIZE_REF=v12.1.0
+
+ENV APP_HOST=0.0.0.0
+ENV APP_PORT=9000
+ENV RECOGNIZE_SRC_DIR=/app/src
+
+WORKDIR /app
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends curl ca-certificates tar \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Fetch the recognize sources (src/ + package.json) at the pinned ref.
+RUN curl -fsSL "https://github.com/nextcloud/recognize/archive/${RECOGNIZE_REF}.tar.gz" -o recognize.tar.gz \
+	&& tar -xzf recognize.tar.gz --strip-components=1 --wildcards \
+		"*/src" "*/package.json" "*/package-lock.json" \
+	&& rm recognize.tar.gz
+
+# Install the recognize node dependencies (Tensorflow.js etc.).
+RUN npm ci --omit=dev
+
+# The ExApp HTTP server.
+COPY server.js ./server.js
+
+# Pre-download the models so the container is ready to classify on first request.
+# (Comment out to download lazily on the AppAPI /init hook instead.)
+RUN node -e "require('./src/model-manager.js').downloadAll()" || echo "Model download deferred to runtime"
+
+EXPOSE 9000
+
+CMD ["node", "server.js"]

--- a/exapp/Makefile
+++ b/exapp/Makefile
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+.DEFAULT_GOAL := help
+
+APP_ID := recognize_exapp
+APP_NAME := Recognize classification backend
+APP_VERSION := $$(xmlstarlet sel -t -v "//version" appinfo/info.xml)
+APP_PORT := 9000
+JSON_INFO := "{\"id\":\"$(APP_ID)\",\"name\":\"$(APP_NAME)\",\"daemon_config_name\":\"manual_install\",\"version\":\"$(APP_VERSION)\",\"secret\":\"12345\",\"port\":$(APP_PORT)}"
+
+.PHONY: help
+help:
+	@echo "  Welcome to $(APP_NAME) $(APP_VERSION)!"
+	@echo " "
+	@echo "  Please use \`make <target>\` where <target> is one of"
+	@echo " "
+	@echo "  build-push        builds the CPU image and uploads it to ghcr.io"
+	@echo "  build-push-gpu    builds the GPU image and uploads it to ghcr.io"
+	@echo " "
+	@echo "  > Commands for the nextcloud-docker-dev environment (run on the host):"
+	@echo " "
+	@echo "  run               registers $(APP_NAME) on Nextcloud Latest via the App Store manifest"
+	@echo "  register          registers a manually-running $(APP_NAME) into the 'manual_install' daemon"
+
+.PHONY: build-push
+build-push:
+	docker login ghcr.io
+	docker buildx build --push --platform linux/amd64 \
+		--build-arg BUILD_TYPE=cpu \
+		--build-arg RECOGNIZE_REF=v$(APP_VERSION) \
+		--tag ghcr.io/nextcloud/$(APP_ID):$(APP_VERSION) \
+		--tag ghcr.io/nextcloud/$(APP_ID):latest .
+
+.PHONY: build-push-gpu
+build-push-gpu:
+	docker login ghcr.io
+	docker buildx build --push --platform linux/amd64 \
+		--build-arg BUILD_TYPE=gpu \
+		--build-arg RECOGNIZE_REF=v$(APP_VERSION) \
+		--tag ghcr.io/nextcloud/$(APP_ID):$(APP_VERSION)-gpu \
+		--tag ghcr.io/nextcloud/$(APP_ID):latest-gpu .
+
+.PHONY: run
+run:
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister $(APP_ID) --silent --force || true
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register $(APP_ID) \
+		--info-xml https://raw.githubusercontent.com/nextcloud/recognize/main/exapp/appinfo/info.xml
+
+.PHONY: register
+register:
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister $(APP_ID) --silent --force || true
+	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register $(APP_ID) manual_install --json-info $(JSON_INFO) --wait-finish

--- a/exapp/README.md
+++ b/exapp/README.md
@@ -1,0 +1,106 @@
+# Recognize ExApp (classification backend container)
+
+This directory contains a Nextcloud **External App** (ExApp) that runs the
+recognize machine-learning classifiers inside a container, so that the heavy
+inference workload can be offloaded from the Nextcloud server to a different,
+more powerful machine — optionally one with a GPU.
+
+This implements the "dedicated devices / ExApp as backend" feature requested in
+[issue #73](https://github.com/nextcloud/recognize/issues/73).
+
+## How it works
+
+```
+┌──────────────────────┐         AppAPI (authenticated HTTP)        ┌─────────────────────────┐
+│ Nextcloud + recognize │  ── POST /classify  (model + image files) ─▶ │ recognize_exapp (this)  │
+│  (classifier.backend  │                                            │  Node.js + Tensorflow.js │
+│        = "exapp")     │  ◀── newline-delimited JSON results ──────── │  classifier_<model>.js   │
+└──────────────────────┘                                            └─────────────────────────┘
+```
+
+The recognize app (PHP) prepares the same downscaled preview images it would
+normally feed to the local `classifier_<model>.js` process, but instead uploads
+them to this ExApp via AppAPI. The ExApp writes them to a temporary directory,
+spawns the *unmodified* `classifier_<model>.js` script (reading paths from stdin,
+just like the local backend), and streams the JSON result lines back. Because the
+same scripts are reused, the results are byte-for-byte compatible with local
+classification.
+
+## Installation (recommended: App Store)
+
+The default and recommended way to deploy this is via the Nextcloud App Store,
+exactly like the other AI ExApps (llm2, context_chat_backend, …):
+
+1. Install the [**AppAPI**](https://apps.nextcloud.com/apps/app_api) app and
+   configure a Deploy Daemon (Administration settings → AppAPI).
+2. Install the [**Recognize**](https://apps.nextcloud.com/apps/recognize) app.
+3. On the **External Apps** page, install **"Recognize classification backend"**.
+   AppAPI pulls the container image (`ghcr.io/nextcloud/recognize_exapp`) and
+   deploys it on your daemon.
+4. In **Administration settings → Recognize → Classification backend**, select
+   *"Offload classification to an External App"*. The App ID defaults to
+   `recognize_exapp` and the connection is verified automatically.
+
+For GPU acceleration, deploy the ExApp on a daemon that runs the GPU image
+variant and set the `RECOGNIZE_GPU` environment variable to `true`.
+
+## Endpoints
+
+| Method | Route        | Purpose                                                              |
+|--------|--------------|----------------------------------------------------------------------|
+| GET    | `/heartbeat` | AppAPI liveness probe (`{"status":"ok"}`)                            |
+| PUT    | `/init`      | AppAPI deploy hook — triggers model download                         |
+| PUT    | `/enabled`   | AppAPI enable/disable hook                                            |
+| POST   | `/classify`  | multipart: `model` field + `files[N]` image files → JSON result lines |
+
+All requests except `/heartbeat` are authenticated using the AppAPI shared secret
+(`AUTHORIZATION-APP-API` header) injected into the container at deploy time.
+
+## Building the image manually
+
+The image is **self-contained**: it fetches the matching recognize sources at
+build time, so it builds straight from this directory:
+
+```sh
+cd exapp
+# CPU
+make build-push            # builds & pushes ghcr.io/nextcloud/recognize_exapp:<version>
+# GPU
+make build-push-gpu
+```
+
+Or directly with Docker:
+
+```sh
+docker build -t recognize_exapp:latest .
+docker build --build-arg BUILD_TYPE=gpu -t recognize_exapp:latest-gpu .
+```
+
+`RECOGNIZE_REF` controls which recognize git tag the classifier sources are
+pulled from (defaults to the version tag; CI sets it to the exact release tag).
+
+## Manual registration (dev / no App Store)
+
+For development with `nextcloud-docker-dev`, or to register a manually-running
+container without the App Store:
+
+```sh
+# register the App Store manifest against a running Nextcloud
+make run
+
+# OR register a container you started yourself into the manual_install daemon
+make register
+```
+
+## Release / publishing
+
+Two GitHub workflows handle releases (see `.github/workflows/exapp-*.yml` in the
+repo root):
+
+* `exapp-publish-docker.yml` — on a `v*` tag, builds and pushes the container
+  image to `ghcr.io/nextcloud/recognize_exapp`.
+* `exapp-appstore-build-publish.yml` — on a published release, packages, signs
+  and uploads the manifest to the Nextcloud App Store.
+
+The `image-tag` in `appinfo/info.xml` must match the `version`, and both must
+match the release tag.

--- a/exapp/appinfo/info.xml
+++ b/exapp/appinfo/info.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<info>
+	<id>recognize_exapp</id>
+	<name>Recognize classification backend</name>
+	<summary>Run the Recognize machine learning classifiers in a container, optionally with GPU</summary>
+	<description><![CDATA[
+**Requires [`AppAPI`](https://apps.nextcloud.com/apps/app_api) and the [Recognize](https://apps.nextcloud.com/apps/recognize) app to work.**
+
+External App (ExApp) that runs the Recognize machine learning classifiers, so the
+inference workload can be offloaded from the Nextcloud server to a different, more
+powerful machine — optionally one with a GPU.
+
+This is useful when:
+
+* your Nextcloud server is small (e.g. a low-power VM, SBC or NAS) and you want to
+  run classification on a beefier machine,
+* you run Nextcloud in a musl/Alpine container (incl. the official Docker image and
+  Nextcloud AIO) where libtensorflow does not run natively,
+* you want to use a GPU for classification without setting up GPU passthrough for
+  the whole Nextcloud container.
+
+After installing this app from the External Apps page, open **Administration
+settings → Recognize → Classification backend** and select *"Offload classification
+to an External App"*.
+
+See https://github.com/nextcloud/recognize/issues/73
+	]]></description>
+	<version>12.1.0</version>
+	<licence>agpl</licence>
+	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
+	<namespace>RecognizeExApp</namespace>
+	<category>ai</category>
+	<category>multimedia</category>
+	<website>https://github.com/nextcloud/recognize</website>
+	<bugs>https://github.com/nextcloud/recognize/issues</bugs>
+	<repository type="git">https://github.com/nextcloud/recognize.git</repository>
+	<screenshot>https://raw.githubusercontent.com/nextcloud/recognize/main/screenshots/Logo.png</screenshot>
+	<dependencies>
+		<nextcloud min-version="30" max-version="35"/>
+	</dependencies>
+	<external-app>
+		<docker-install>
+			<registry>ghcr.io</registry>
+			<image>nextcloud/recognize_exapp</image>
+			<image-tag>12.1.0</image-tag>
+		</docker-install>
+		<!-- No special scopes required: recognize only POSTs image bytes and reads
+		     back JSON results; the ExApp never accesses Nextcloud data itself. -->
+		<system>false</system>
+		<environment-variables>
+			<variable>
+				<name>RECOGNIZE_GPU</name>
+				<display-name>Enable GPU mode</display-name>
+				<description>Set to "true" to use the GPU for classification. Requires the GPU image variant and a working CUDA/cuDNN setup with GPU passthrough into the container.</description>
+			</variable>
+		</environment-variables>
+	</external-app>
+</info>

--- a/exapp/krankerl.toml
+++ b/exapp/krankerl.toml
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+[package]
+before_cmds = []

--- a/exapp/server.js
+++ b/exapp/server.js
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2024 The Recognize contributors.
+ * This file is licensed under the Affero General Public License version 3 or later. See the COPYING file.
+ *
+ * Minimal HTTP server that turns the recognize classifier scripts into a
+ * Nextcloud External App (ExApp) classification backend.
+ *
+ * It deliberately reuses the *unmodified* `classifier_<model>.js` scripts from
+ * the recognize `src/` directory: they read newline-separated file paths from
+ * stdin and emit one JSON line per file to stdout. This server simply receives
+ * the uploaded image files over HTTP, spawns the right classifier script, and
+ * streams its stdout back. See ./README.md for the full picture.
+ */
+
+const http = require('http')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const crypto = require('crypto')
+const { spawn } = require('child_process')
+
+// The recognize sources are copied into ../src relative to this file in the image.
+const SRC_DIR = process.env.RECOGNIZE_SRC_DIR || path.join(__dirname, 'src')
+
+const PORT = parseInt(process.env.APP_PORT || '9000', 10)
+const HOST = process.env.APP_HOST || '0.0.0.0'
+// Shared secret injected by AppAPI on deploy. Requests must present it.
+const APP_SECRET = process.env.APP_SECRET || ''
+const APP_ID = process.env.APP_ID || 'recognize_exapp'
+
+const ALLOWED_MODELS = ['imagenet', 'landmarks', 'faces', 'movinet', 'musicnn']
+
+/**
+ * Verify the AppAPI authentication headers.
+ * AppAPI signs requests with the shared APP_SECRET; we compare it in constant time.
+ *
+ * @param {http.IncomingMessage} req
+ * @return {boolean}
+ */
+function isAuthenticated(req) {
+	if (!APP_SECRET) {
+		// No secret configured (e.g. local manual testing): allow.
+		return true
+	}
+	const provided = req.headers['authorization-app-api'] || ''
+	// AppAPI sends base64("userId:appSecret"); we only check the secret part.
+	let secret = ''
+	try {
+		const decoded = Buffer.from(String(provided), 'base64').toString('utf8')
+		secret = decoded.slice(decoded.indexOf(':') + 1)
+	} catch (e) {
+		return false
+	}
+	const a = Buffer.from(secret)
+	const b = Buffer.from(APP_SECRET)
+	return a.length === b.length && crypto.timingSafeEqual(a, b)
+}
+
+/**
+ * Parse a multipart/form-data body into { fields, files }.
+ * Minimal parser sufficient for the recognize payload (a `model` field and
+ * `files[N]` file parts). Avoids pulling in an extra dependency.
+ *
+ * @param {Buffer} body
+ * @param {string} boundary
+ */
+function parseMultipart(body, boundary) {
+	const fields = {}
+	const files = []
+	const delimiter = Buffer.from('--' + boundary)
+	let start = body.indexOf(delimiter)
+	while (start !== -1) {
+		const next = body.indexOf(delimiter, start + delimiter.length)
+		if (next === -1) {
+			break
+		}
+		// part is between this delimiter and the next, skipping the trailing CRLF after the boundary
+		let part = body.subarray(start + delimiter.length, next)
+		// strip leading CRLF
+		if (part[0] === 0x0d && part[1] === 0x0a) {
+			part = part.subarray(2)
+		}
+		const headerEnd = part.indexOf('\r\n\r\n')
+		if (headerEnd !== -1) {
+			const rawHeaders = part.subarray(0, headerEnd).toString('utf8')
+			// strip trailing CRLF of the content
+			let content = part.subarray(headerEnd + 4)
+			if (content.length >= 2 && content[content.length - 2] === 0x0d && content[content.length - 1] === 0x0a) {
+				content = content.subarray(0, content.length - 2)
+			}
+			const nameMatch = rawHeaders.match(/name="([^"]*)"/i)
+			const filenameMatch = rawHeaders.match(/filename="([^"]*)"/i)
+			const name = nameMatch ? nameMatch[1] : null
+			if (name !== null) {
+				if (filenameMatch) {
+					files.push({ name, filename: filenameMatch[1], content })
+				} else {
+					fields[name] = content.toString('utf8')
+				}
+			}
+		}
+		start = next
+	}
+	return { fields, files }
+}
+
+/**
+ * Run the recognize classifier script for the given model on the given file paths.
+ * Resolves with the raw stdout (newline-delimited JSON), one line per file.
+ *
+ * @param {string} model
+ * @param {string[]} filePaths
+ * @return {Promise<string>}
+ */
+function runClassifier(model, filePaths) {
+	return new Promise((resolve, reject) => {
+		const script = path.join(SRC_DIR, `classifier_${model}.js`)
+		if (!fs.existsSync(script)) {
+			reject(new Error(`Unknown classifier script for model "${model}"`))
+			return
+		}
+		const env = { ...process.env }
+		if (process.env.RECOGNIZE_GPU === 'true') {
+			env.RECOGNIZE_GPU = 'true'
+		}
+		if (process.env.RECOGNIZE_PUREJS === 'true') {
+			env.RECOGNIZE_PUREJS = 'true'
+		}
+		const child = spawn(process.execPath, [script, '-'], { cwd: SRC_DIR, env })
+		let stdout = ''
+		let stderr = ''
+		child.stdout.on('data', d => { stdout += d.toString('utf8') })
+		child.stderr.on('data', d => { stderr += d.toString('utf8') })
+		child.on('error', reject)
+		child.on('close', code => {
+			if (code !== 0) {
+				reject(new Error(`Classifier process exited with code ${code}: ${stderr}`))
+				return
+			}
+			resolve(stdout)
+		})
+		child.stdin.write(filePaths.join('\n'))
+		child.stdin.end()
+	})
+}
+
+/**
+ * @param {http.IncomingMessage} req
+ * @return {Promise<Buffer>}
+ */
+function readBody(req) {
+	return new Promise((resolve, reject) => {
+		const chunks = []
+		req.on('data', c => chunks.push(c))
+		req.on('end', () => resolve(Buffer.concat(chunks)))
+		req.on('error', reject)
+	})
+}
+
+function sendJson(res, status, obj) {
+	const body = JSON.stringify(obj)
+	res.writeHead(status, { 'Content-Type': 'application/json' })
+	res.end(body)
+}
+
+const server = http.createServer(async (req, res) => {
+	const url = new URL(req.url, `http://${req.headers.host}`)
+
+	// Liveness probe — must be unauthenticated per AppAPI conventions.
+	if (req.method === 'GET' && url.pathname === '/heartbeat') {
+		sendJson(res, 200, { status: 'ok' })
+		return
+	}
+
+	if (!isAuthenticated(req)) {
+		sendJson(res, 401, { error: 'Unauthorized' })
+		return
+	}
+
+	// AppAPI lifecycle hooks.
+	if (req.method === 'PUT' && url.pathname === '/init') {
+		// Kick off model download in the background so first classification is fast.
+		try {
+			const { downloadAll } = require(path.join(SRC_DIR, 'model-manager.js'))
+			downloadAll().catch(e => console.error('Model download failed', e))
+		} catch (e) {
+			console.error('Could not start model download', e)
+		}
+		sendJson(res, 200, {})
+		return
+	}
+	if (req.method === 'PUT' && url.pathname === '/enabled') {
+		sendJson(res, 200, {})
+		return
+	}
+
+	if (req.method === 'POST' && url.pathname === '/classify') {
+		const contentType = req.headers['content-type'] || ''
+		const boundaryMatch = contentType.match(/boundary=(.+)$/)
+		if (!boundaryMatch) {
+			sendJson(res, 400, { error: 'Expected multipart/form-data' })
+			return
+		}
+		let tmpDir
+		try {
+			const body = await readBody(req)
+			const { fields, files } = parseMultipart(body, boundaryMatch[1].replace(/^"|"$/g, ''))
+			const model = fields.model
+			if (!ALLOWED_MODELS.includes(model)) {
+				sendJson(res, 400, { error: `Unsupported model "${model}"` })
+				return
+			}
+			if (files.length === 0) {
+				sendJson(res, 400, { error: 'No files provided' })
+				return
+			}
+			// Preserve the upload order (files[0], files[1], ...) so results map back correctly.
+			files.sort((a, b) => {
+				const ai = parseInt((a.name.match(/\[(\d+)\]/) || [])[1] || '0', 10)
+				const bi = parseInt((b.name.match(/\[(\d+)\]/) || [])[1] || '0', 10)
+				return ai - bi
+			})
+
+			tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'recognize-exapp-'))
+			const filePaths = files.map((f, i) => {
+				const ext = path.extname(f.filename || '') || '.jpg'
+				const p = path.join(tmpDir, `${i}${ext}`)
+				fs.writeFileSync(p, f.content)
+				return p
+			})
+
+			const output = await runClassifier(model, filePaths)
+			res.writeHead(200, { 'Content-Type': 'application/x-ndjson' })
+			res.end(output)
+		} catch (e) {
+			console.error('Classification failed', e)
+			sendJson(res, 500, { error: String(e.message || e) })
+		} finally {
+			if (tmpDir) {
+				fs.rm(tmpDir, { recursive: true, force: true }, () => {})
+			}
+		}
+		return
+	}
+
+	sendJson(res, 404, { error: 'Not found' })
+})
+
+server.listen(PORT, HOST, () => {
+	console.log(`recognize ExApp "${APP_ID}" listening on ${HOST}:${PORT}`)
+})

--- a/exapp/test/server.test.js
+++ b/exapp/test/server.test.js
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2024 The Recognize contributors.
+ * This file is licensed under the Affero General Public License version 3 or later. See the COPYING file.
+ *
+ * Standalone functional test for the ExApp server. It does NOT require the real
+ * recognize sources or TensorFlow: it points RECOGNIZE_SRC_DIR at a fixture dir
+ * containing a stub `classifier_<model>.js` that echoes one JSON line per input
+ * file, then exercises the real HTTP endpoints.
+ *
+ * Run with:  node exapp/test/server.test.js
+ */
+
+const http = require('http')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+let failures = 0
+let passed = 0
+function assert(cond, msg) {
+	if (cond) {
+		passed++
+		console.log('  ok  - ' + msg)
+	} else {
+		failures++
+		console.error('  FAIL- ' + msg)
+	}
+}
+
+// --- Build a fixture src dir with a stub classifier + model-manager -----------
+const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'recognize-exapp-fixture-'))
+const srcDir = path.join(fixtureDir, 'src')
+fs.mkdirSync(srcDir)
+
+// Stub classifier: reads newline-separated paths from stdin, prints one JSON
+// line per file echoing the file's first byte so we can verify ordering.
+fs.writeFileSync(path.join(srcDir, 'classifier_imagenet.js'), `
+const fs = require('fs')
+let input = ''
+process.stdin.on('data', d => { input += d })
+process.stdin.on('end', () => {
+	const paths = input.split('\\n').filter(p => p.trim() !== '')
+	for (const p of paths) {
+		const content = fs.readFileSync(p, 'utf8')
+		console.log(JSON.stringify(['tag:' + content.trim()]))
+	}
+	process.exit(0)
+})
+`)
+// A model-manager stub so /init does not blow up.
+fs.writeFileSync(path.join(srcDir, 'model-manager.js'), 'exports.downloadAll = async () => {}\n')
+
+const APP_SECRET = 's3cr3t'
+const APP_PORT = 19123
+// AppAPI sends AUTHORIZATION-APP-API as raw base64("userId:appSecret"), no "Basic " prefix.
+const authHeader = Buffer.from('admin:' + APP_SECRET).toString('base64')
+
+// --- Spawn the server under test ---------------------------------------------
+const { spawn } = require('child_process')
+const serverPath = path.join(__dirname, '..', 'server.js')
+const child = spawn(process.execPath, [serverPath], {
+	env: {
+		...process.env,
+		RECOGNIZE_SRC_DIR: srcDir,
+		APP_SECRET,
+		APP_PORT: String(APP_PORT),
+		APP_HOST: '127.0.0.1',
+	},
+	stdio: ['ignore', 'pipe', 'pipe'],
+})
+child.stderr.on('data', d => process.stderr.write('[server] ' + d))
+
+function request(method, pathname, headers = {}, body = null) {
+	return new Promise((resolve, reject) => {
+		const req = http.request({ host: '127.0.0.1', port: APP_PORT, method, path: pathname, headers }, res => {
+			const chunks = []
+			res.on('data', c => chunks.push(c))
+			res.on('end', () => resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks).toString('utf8') }))
+		})
+		req.on('error', reject)
+		if (body) req.write(body)
+		req.end()
+	})
+}
+
+function buildMultipart(model, files) {
+	const boundary = '----testboundary' + Math.floor(performance.now())
+	const parts = []
+	parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="model"\r\n\r\n${model}\r\n`))
+	files.forEach((f, i) => {
+		parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="files[${i}]"; filename="${f.filename}"\r\nContent-Type: application/octet-stream\r\n\r\n`))
+		parts.push(Buffer.from(f.content))
+		parts.push(Buffer.from('\r\n'))
+	})
+	parts.push(Buffer.from(`--${boundary}--\r\n`))
+	return { boundary, body: Buffer.concat(parts) }
+}
+
+async function waitForServer() {
+	for (let i = 0; i < 50; i++) {
+		try {
+			const r = await request('GET', '/heartbeat')
+			if (r.status === 200) return
+		} catch (e) { /* not up yet */ }
+		await new Promise(r => setTimeout(r, 100))
+	}
+	throw new Error('server did not start')
+}
+
+async function run() {
+	await waitForServer()
+
+	// 1. heartbeat is unauthenticated and returns ok
+	let r = await request('GET', '/heartbeat')
+	assert(r.status === 200 && JSON.parse(r.body).status === 'ok', 'GET /heartbeat returns {status:ok} without auth')
+
+	// 2. classify without auth is rejected
+	const mp0 = buildMultipart('imagenet', [{ filename: 'a.jpg', content: 'A' }])
+	r = await request('POST', '/classify', { 'Content-Type': `multipart/form-data; boundary=${mp0.boundary}` }, mp0.body)
+	assert(r.status === 401, 'POST /classify without auth → 401')
+
+	// 3. classify with auth: results returned, in order, one JSON line per file
+	const mp = buildMultipart('imagenet', [
+		{ filename: '0.jpg', content: 'zero' },
+		{ filename: '1.jpg', content: 'one' },
+		{ filename: '2.jpg', content: 'two' },
+	])
+	r = await request('POST', '/classify', {
+		'Content-Type': `multipart/form-data; boundary=${mp.boundary}`,
+		'Authorization-App-Api': authHeader,
+	}, mp.body)
+	assert(r.status === 200, 'POST /classify with auth → 200')
+	const lines = r.body.split('\n').filter(l => l.trim() !== '')
+	assert(lines.length === 3, `classify returns one line per file (got ${lines.length})`)
+	const parsed = lines.map(l => JSON.parse(l))
+	assert(JSON.stringify(parsed[0]) === JSON.stringify(['tag:zero'])
+		&& JSON.stringify(parsed[1]) === JSON.stringify(['tag:one'])
+		&& JSON.stringify(parsed[2]) === JSON.stringify(['tag:two']),
+	'classify preserves file order (files[0..2] → zero,one,two)')
+
+	// 4. files provided out of order are sorted back by index
+	const boundary = '----oob' + Math.floor(performance.now())
+	const oob = Buffer.concat([
+		Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="model"\r\n\r\nimagenet\r\n`),
+		Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="files[1]"; filename="1.jpg"\r\n\r\n`),
+		Buffer.from('second'),
+		Buffer.from(`\r\n--${boundary}\r\nContent-Disposition: form-data; name="files[0]"; filename="0.jpg"\r\n\r\n`),
+		Buffer.from('first'),
+		Buffer.from(`\r\n--${boundary}--\r\n`),
+	])
+	r = await request('POST', '/classify', {
+		'Content-Type': `multipart/form-data; boundary=${boundary}`,
+		'Authorization-App-Api': authHeader,
+	}, oob)
+	const oobLines = r.body.split('\n').filter(l => l.trim() !== '').map(l => JSON.parse(l))
+	assert(r.status === 200 && JSON.stringify(oobLines[0]) === JSON.stringify(['tag:first'])
+		&& JSON.stringify(oobLines[1]) === JSON.stringify(['tag:second']),
+	'classify sorts files[1],files[0] back into 0,1 order')
+
+	// 5. unsupported model rejected
+	const bad = buildMultipart('definitely_not_a_model', [{ filename: 'a.jpg', content: 'A' }])
+	r = await request('POST', '/classify', {
+		'Content-Type': `multipart/form-data; boundary=${bad.boundary}`,
+		'Authorization-App-Api': authHeader,
+	}, bad.body)
+	assert(r.status === 400, 'POST /classify with unsupported model → 400')
+
+	// 6. no files rejected
+	const nofiles = buildMultipart('imagenet', [])
+	r = await request('POST', '/classify', {
+		'Content-Type': `multipart/form-data; boundary=${nofiles.boundary}`,
+		'Authorization-App-Api': authHeader,
+	}, nofiles.body)
+	assert(r.status === 400, 'POST /classify with no files → 400')
+
+	// 7. non-multipart classify rejected
+	r = await request('POST', '/classify', { 'Content-Type': 'application/json', 'Authorization-App-Api': authHeader }, '{}')
+	assert(r.status === 400, 'POST /classify non-multipart → 400')
+
+	// 8. lifecycle hooks
+	r = await request('PUT', '/init', { 'Authorization-App-Api': authHeader })
+	assert(r.status === 200, 'PUT /init → 200')
+	r = await request('PUT', '/enabled', { 'Authorization-App-Api': authHeader })
+	assert(r.status === 200, 'PUT /enabled → 200')
+
+	// 9. wrong secret rejected
+	const wrong = Buffer.from('admin:wrongsecret').toString('base64')
+	r = await request('PUT', '/enabled', { 'Authorization-App-Api': wrong })
+	assert(r.status === 401, 'wrong secret → 401')
+
+	// 10. unknown route
+	r = await request('GET', '/nope', { 'Authorization-App-Api': authHeader })
+	assert(r.status === 404, 'unknown route → 404')
+}
+
+run()
+	.catch(e => { console.error(e); failures++ })
+	.finally(() => {
+		child.kill()
+		fs.rmSync(fixtureDir, { recursive: true, force: true })
+		console.log(`\n${passed} passed, ${failures} failed`)
+		process.exit(failures === 0 ? 0 : 1)
+	})

--- a/lib/Classifiers/Classifier.php
+++ b/lib/Classifiers/Classifier.php
@@ -12,6 +12,7 @@ use OCA\Recognize\Classifiers\Images\ImagenetClassifier;
 use OCA\Recognize\Classifiers\Images\LandmarksClassifier;
 use OCA\Recognize\Constants;
 use OCA\Recognize\Db\QueueFile;
+use OCA\Recognize\Service\ExAppService;
 use OCA\Recognize\Service\QueueService;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\DB\Exception;
@@ -158,6 +159,54 @@ abstract class Classifier {
 
 		$this->logger->debug('Classifying '.var_export($paths, true));
 
+		// Pick the execution backend: either run node.js locally (default) or
+		// offload the inference to an External App / container.
+		// See https://github.com/nextcloud/recognize/issues/73
+		if ($this->config->getAppValueString('classifier.backend', 'local', lazy: true) === 'exapp') {
+			$lines = $this->runExApp($model, $paths, $timeout);
+		} else {
+			$lines = $this->runLocally($model, $paths, $timeout, $startTime);
+		}
+
+		$i = 0;
+		foreach ($lines as $result) {
+			if ($this->maxExecutionTime > 0 && time() - $startTime > $this->maxExecutionTime) {
+				$this->cleanUpTmpFiles();
+				return;
+			}
+			$this->logger->debug('Result for ' . $fileNames[$i] .'(' . basename($paths[$i]) . ') = ' . $result);
+			try {
+				// decode json
+				$results = json_decode($result, true, 512, JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_IGNORE);
+				yield $processedFiles[$i] => $results;
+				$this->queue->removeFromQueue($model, $processedFiles[$i]);
+			} catch (\JsonException $e) {
+				$this->logger->warning('JSON exception');
+				$this->logger->warning($e->getMessage(), ['exception' => $e]);
+				$this->logger->warning($result);
+			} catch (Exception $e) {
+				$this->logger->warning($e->getMessage(), ['exception' => $e]);
+			}
+			$i++;
+		}
+		$this->cleanUpTmpFiles();
+		if ($i !== count($paths)) {
+			throw new \ErrorException('Classifier process error');
+		}
+	}
+
+	/**
+	 * Run the classifier node.js process locally and yield each valid JSON result line.
+	 *
+	 * @param string $model
+	 * @param list<string> $paths
+	 * @param int $timeout
+	 * @param int $startTime
+	 * @return \Generator
+	 * @psalm-return \Generator<int, string, mixed, void>
+	 * @throws \ErrorException|\RuntimeException
+	 */
+	private function runLocally(string $model, array $paths, int $timeout, int $startTime): \Generator {
 		$command = [
 			$this->config->getAppValueString('node_binary', lazy: true),
 			dirname(__DIR__, 2) . '/src/classifier_'.$model.'.js',
@@ -197,18 +246,14 @@ abstract class Classifier {
 				@exec('taskset -cp ' . implode(',', range(0, (int)$cores, 1)) . ' ' . ((string)$proc->getPid()));
 			}
 
-			$i = 0;
-			$errOut = '';
 			$buffer = '';
 			foreach ($proc as $type => $data) {
 				if ($type !== $proc::OUT) {
-					$errOut .= $data;
 					$this->logger->debug('Classifier process output: '.$data);
 					continue;
 				}
 				if ($this->maxExecutionTime > 0 && time() - $startTime > $this->maxExecutionTime) {
 					$proc->stop(10, 9);
-					$this->cleanUpTmpFiles();
 					return;
 				}
 				$buffer .= $data;
@@ -228,36 +273,90 @@ abstract class Classifier {
 						$buffer .= "\n".$result;
 						continue;
 					}
-					$this->logger->debug('Result for ' . $fileNames[$i] .'(' . basename($paths[$i]) . ') = ' . $result);
-					try {
-						// decode json
-						$results = json_decode($result, true, 512, JSON_OBJECT_AS_ARRAY | JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_IGNORE);
-						yield $processedFiles[$i] => $results;
-						$this->queue->removeFromQueue($model, $processedFiles[$i]);
-					} catch (\JsonException $e) {
-						$this->logger->warning('JSON exception');
-						$this->logger->warning($e->getMessage(), ['exception' => $e]);
-						$this->logger->warning($result);
-					} catch (Exception $e) {
-						$this->logger->warning($e->getMessage(), ['exception' => $e]);
-					}
-					$i++;
+					yield $result;
 				}
 			}
 			$proc->stop();
-			$this->cleanUpTmpFiles();
-			if ($i !== count($paths)) {
-				$this->logger->warning('Classifier process output: '.$errOut);
-				throw new \ErrorException('Classifier process error');
-			}
 		} catch (ProcessTimedOutException $e) {
-			$this->cleanUpTmpFiles();
 			$this->logger->warning($proc->getErrorOutput());
 			throw new \RuntimeException('Classifier process timeout');
 		} catch (RuntimeException $e) {
-			$this->cleanUpTmpFiles();
 			$this->logger->warning($proc->getErrorOutput());
 			throw new \ErrorException('Classifier process could not be started');
+		}
+	}
+
+	/**
+	 * Offload the classification to a recognize ExApp (container) via AppAPI.
+	 *
+	 * The converted/downscaled image files are uploaded to the ExApp, which runs
+	 * the same classifier_<model>.js scripts and returns one JSON result line per
+	 * input file in the original order, just like the local node.js process.
+	 *
+	 * @param string $model
+	 * @param list<string> $paths
+	 * @param int $timeout
+	 * @return \Generator
+	 * @psalm-return \Generator<int, string, mixed, void>
+	 * @throws \ErrorException
+	 */
+	private function runExApp(string $model, array $paths, int $timeout): \Generator {
+		$exAppService = \OCP\Server::get(ExAppService::class);
+		$appId = $this->config->getAppValueString('exapp.id', 'recognize_exapp', lazy: true);
+
+		if (!$exAppService->isExAppEnabled($appId)) {
+			throw new \ErrorException('Recognize ExApp "' . $appId . '" is not deployed or not enabled');
+		}
+
+		$this->logger->debug('Offloading classification of ' . count($paths) . ' files to ExApp ' . $appId);
+
+		// Build a multipart request: the model name plus each image file's bytes.
+		$multipart = [
+			['name' => 'model', 'contents' => $model],
+		];
+		foreach ($paths as $index => $path) {
+			$contents = @file_get_contents($path);
+			if ($contents === false) {
+				throw new \ErrorException('Could not read file for ExApp classification: ' . $path);
+			}
+			$multipart[] = [
+				'name' => 'files[' . $index . ']',
+				'contents' => $contents,
+				'filename' => basename($path),
+			];
+		}
+
+		try {
+			$response = $exAppService->request($appId, '/classify', 'POST', [], [
+				'multipart' => $multipart,
+				'timeout' => count($paths) * $timeout,
+			]);
+		} catch (\Throwable $e) {
+			$this->logger->warning('ExApp classification request failed', ['exception' => $e]);
+			throw new \ErrorException('ExApp classification failed: ' . $e->getMessage());
+		}
+
+		// The ExApp returns the newline-delimited JSON results, one line per file,
+		// in the same order as the uploaded files.
+		if (is_array($response)) {
+			$body = isset($response['body']) && is_string($response['body']) ? $response['body'] : '';
+		} else {
+			$status = $response->getStatusCode();
+			$body = $response->getBody();
+			if (!is_string($body)) {
+				$body = (string)$body;
+			}
+			if ($status >= 400) {
+				$this->logger->warning('ExApp classification returned status ' . $status . ': ' . $body);
+				throw new \ErrorException('ExApp classification returned status ' . $status);
+			}
+		}
+
+		foreach (explode("\n", $body) as $result) {
+			if (trim($result) === '') {
+				continue;
+			}
+			yield $result;
 		}
 	}
 

--- a/lib/Classifiers/Classifier.php
+++ b/lib/Classifiers/Classifier.php
@@ -203,7 +203,7 @@ abstract class Classifier {
 	 * @param int $timeout
 	 * @param int $startTime
 	 * @return \Generator
-	 * @psalm-return \Generator<int, string, mixed, void>
+	 * @psalm-return \Generator<int, string, mixed, null>
 	 * @throws \ErrorException|\RuntimeException
 	 */
 	private function runLocally(string $model, array $paths, int $timeout, int $startTime): \Generator {
@@ -297,7 +297,7 @@ abstract class Classifier {
 	 * @param list<string> $paths
 	 * @param int $timeout
 	 * @return \Generator
-	 * @psalm-return \Generator<int, string, mixed, void>
+	 * @psalm-return \Generator<int, string, mixed, null>
 	 * @throws \ErrorException
 	 */
 	private function runExApp(string $model, array $paths, int $timeout): \Generator {

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -236,7 +236,7 @@ final class AdminController extends Controller {
 		$appId = $this->settingsService->getSetting('exapp.id');
 		$exApp = $this->exAppService->getExApp($appId);
 
-		if ($exApp === null || !($exApp['enabled'] ?? false)) {
+		if ($exApp === null || !(bool)($exApp['enabled'] ?? false)) {
 			return new JSONResponse(['exapp' => false]);
 		}
 

--- a/lib/Controller/AdminController.php
+++ b/lib/Controller/AdminController.php
@@ -19,6 +19,7 @@ use OCA\Recognize\BackgroundJobs\SchedulerJob;
 use OCA\Recognize\BackgroundJobs\StorageCrawlJob;
 use OCA\Recognize\Db\FaceClusterMapper;
 use OCA\Recognize\Db\FaceDetectionMapper;
+use OCA\Recognize\Service\ExAppService;
 use OCA\Recognize\Service\QueueService;
 use OCA\Recognize\Service\SettingsService;
 use OCA\Recognize\Service\TagManager;
@@ -43,8 +44,9 @@ final class AdminController extends Controller {
 	private IAppConfig $config;
 	private FaceDetectionMapper $faceDetections;
 	private IBinaryFinder $binaryFinder;
+	private ExAppService $exAppService;
 
-	public function __construct(string $appName, IRequest $request, TagManager $tagManager, IJobList $jobList, SettingsService $settingsService, QueueService $queue, FaceClusterMapper $clusterMapper, FaceDetectionMapper $detectionMapper, IAppConfig $config, FaceDetectionMapper $faceDetections, IBinaryFinder $binaryFinder) {
+	public function __construct(string $appName, IRequest $request, TagManager $tagManager, IJobList $jobList, SettingsService $settingsService, QueueService $queue, FaceClusterMapper $clusterMapper, FaceDetectionMapper $detectionMapper, IAppConfig $config, FaceDetectionMapper $faceDetections, IBinaryFinder $binaryFinder, ExAppService $exAppService) {
 		parent::__construct($appName, $request);
 		$this->tagManager = $tagManager;
 		$this->jobList = $jobList;
@@ -55,6 +57,7 @@ final class AdminController extends Controller {
 		$this->config = $config;
 		$this->faceDetections = $faceDetections;
 		$this->binaryFinder = $binaryFinder;
+		$this->exAppService = $exAppService;
 	}
 
 	public function reset(): JSONResponse {
@@ -217,6 +220,34 @@ final class AdminController extends Controller {
 
 		$version = trim(implode("\n", $output));
 		return new JSONResponse(['nodejs' => $version]);
+	}
+
+	/**
+	 * Test connectivity to the configured recognize ExApp.
+	 *
+	 * Returns the ExApp version string on success, false if the ExApp is not
+	 * deployed/enabled, or null if AppAPI is not installed at all.
+	 */
+	public function exapp(): JSONResponse {
+		if (!$this->exAppService->isAppApiAvailable()) {
+			return new JSONResponse(['exapp' => null]);
+		}
+
+		$appId = $this->settingsService->getSetting('exapp.id');
+		$exApp = $this->exAppService->getExApp($appId);
+
+		if ($exApp === null || !($exApp['enabled'] ?? false)) {
+			return new JSONResponse(['exapp' => false]);
+		}
+
+		// Ping the ExApp's status route to make sure it is actually reachable.
+		try {
+			$response = $this->exAppService->request($appId, '/heartbeat', 'GET', [], ['timeout' => 5]);
+		} catch (\Throwable $e) {
+			return new JSONResponse(['exapp' => false]);
+		}
+
+		return new JSONResponse(['exapp' => $exApp['version'] ?? true]);
 	}
 
 	public function ffmpeg(): JSONResponse {

--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) 2024 The Recognize contributors.
+ * This file is licensed under the Affero General Public License version 3 or later. See the COPYING file.
+ */
+
+namespace OCA\Recognize\Service;
+
+use OCP\App\IAppManager;
+use OCP\Http\Client\IResponse;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Thin wrapper around the AppAPI PublicFunctions service.
+ *
+ * The recognize classifiers can optionally offload the actual node.js inference
+ * to an External App (a.k.a. ExApp), which is a container that ships the same
+ * classifier_*.js scripts and (optionally) GPU support. This lets users run the
+ * heavy machine learning workload on a different, more powerful machine than the
+ * one hosting Nextcloud, as requested in
+ * https://github.com/nextcloud/recognize/issues/73
+ *
+ * AppAPI is an optional dependency: every method here degrades gracefully when
+ * the app_api app is not installed, so recognize keeps working with the local
+ * node.js backend.
+ */
+class ExAppService {
+	private const APP_API_APP_ID = 'app_api';
+	private const APP_API_PUBLIC_FUNCTIONS = 'OCA\\AppAPI\\PublicFunctions';
+
+	public function __construct(
+		private IAppManager $appManager,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Whether the AppAPI app is installed and enabled, so that ExApp requests
+	 * can be made at all.
+	 */
+	public function isAppApiAvailable(): bool {
+		return $this->appManager->isEnabledForAnyone(self::APP_API_APP_ID)
+			&& class_exists(self::APP_API_PUBLIC_FUNCTIONS);
+	}
+
+	/**
+	 * Returns the AppAPI PublicFunctions service or null if AppAPI is unavailable.
+	 *
+	 * @psalm-suppress UndefinedClass AppAPI is an optional dependency
+	 */
+	private function getPublicFunctions(): ?object {
+		if (!$this->isAppApiAvailable()) {
+			return null;
+		}
+		try {
+			/** @psalm-suppress UndefinedClass */
+			return \OCP\Server::get(self::APP_API_PUBLIC_FUNCTIONS);
+		} catch (\Throwable $e) {
+			$this->logger->warning('Could not load AppAPI PublicFunctions', ['exception' => $e]);
+			return null;
+		}
+	}
+
+	/**
+	 * Returns ExApp metadata (appid, version, name, enabled) or null if not found
+	 * or AppAPI is unavailable.
+	 */
+	public function getExApp(string $appId): ?array {
+		$publicFunctions = $this->getPublicFunctions();
+		if ($publicFunctions === null) {
+			return null;
+		}
+		try {
+			/** @psalm-suppress UndefinedClass */
+			return $publicFunctions->getExApp($appId);
+		} catch (\Throwable $e) {
+			$this->logger->warning('Could not query ExApp ' . $appId, ['exception' => $e]);
+			return null;
+		}
+	}
+
+	/**
+	 * Whether the given ExApp is deployed and enabled.
+	 */
+	public function isExAppEnabled(string $appId): bool {
+		$exApp = $this->getExApp($appId);
+		return $exApp !== null && (bool)($exApp['enabled'] ?? false);
+	}
+
+	/**
+	 * Perform a request to an ExApp using AppAPI's authenticated channel.
+	 *
+	 * @param array $params JSON body params (ignored if $options['multipart'] is set)
+	 * @param array $options Guzzle/IClient request options (multipart, timeout, headers, ...)
+	 * @return array|IResponse The decoded response array or an IResponse on success
+	 * @throws \RuntimeException If AppAPI is unavailable or the request fails
+	 */
+	public function request(string $appId, string $route, string $method = 'POST', array $params = [], array $options = []): array|IResponse {
+		$publicFunctions = $this->getPublicFunctions();
+		if ($publicFunctions === null) {
+			throw new \RuntimeException('AppAPI is not available, cannot reach ExApp ' . $appId);
+		}
+
+		/** @psalm-suppress UndefinedClass */
+		$response = $publicFunctions->exAppRequest($appId, $route, null, $method, $params, $options);
+
+		if (is_array($response) && isset($response['error'])) {
+			throw new \RuntimeException('ExApp request to ' . $appId . $route . ' failed: ' . $response['error']);
+		}
+
+		return $response;
+	}
+}

--- a/lib/Service/ExAppService.php
+++ b/lib/Service/ExAppService.php
@@ -27,7 +27,7 @@ use Psr\Log\LoggerInterface;
  * the app_api app is not installed, so recognize keeps working with the local
  * node.js backend.
  */
-class ExAppService {
+final class ExAppService {
 	private const APP_API_APP_ID = 'app_api';
 	private const APP_API_PUBLIC_FUNCTIONS = 'OCA\\AppAPI\\PublicFunctions';
 
@@ -56,7 +56,10 @@ class ExAppService {
 			return null;
 		}
 		try {
-			/** @psalm-suppress UndefinedClass */
+			/**
+			 * @psalm-suppress UndefinedClass AppAPI is an optional dependency
+			 * @psalm-suppress MixedReturnStatement
+			 */
 			return \OCP\Server::get(self::APP_API_PUBLIC_FUNCTIONS);
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not load AppAPI PublicFunctions', ['exception' => $e]);
@@ -74,7 +77,11 @@ class ExAppService {
 			return null;
 		}
 		try {
-			/** @psalm-suppress UndefinedClass */
+			/**
+			 * @psalm-suppress UndefinedClass AppAPI is an optional dependency
+			 * @psalm-suppress MixedReturnStatement
+			 * @psalm-suppress MixedMethodCall
+			 */
 			return $publicFunctions->getExApp($appId);
 		} catch (\Throwable $e) {
 			$this->logger->warning('Could not query ExApp ' . $appId, ['exception' => $e]);
@@ -104,13 +111,18 @@ class ExAppService {
 			throw new \RuntimeException('AppAPI is not available, cannot reach ExApp ' . $appId);
 		}
 
-		/** @psalm-suppress UndefinedClass */
+		/**
+		 * @psalm-suppress UndefinedClass AppAPI is an optional dependency
+		 * @psalm-suppress MixedAssignment
+		 * @psalm-suppress MixedMethodCall
+		 */
 		$response = $publicFunctions->exAppRequest($appId, $route, null, $method, $params, $options);
 
 		if (is_array($response) && isset($response['error'])) {
-			throw new \RuntimeException('ExApp request to ' . $appId . $route . ' failed: ' . $response['error']);
+			throw new \RuntimeException('ExApp request to ' . $appId . $route . ' failed: ' . (string)$response['error']);
 		}
 
+		/** @psalm-suppress MixedReturnStatement */
 		return $response;
 	}
 }

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -53,6 +53,10 @@ final class SettingsService {
 		'nice_value' => '0',
 		'concurrency.enabled' => 'false',
 		'ffmpeg_binary' => '',
+		// Classifier execution backend: 'local' (run node.js locally) or 'exapp' (offload to an External App / container)
+		'classifier.backend' => 'local',
+		// The appId of the recognize ExApp to offload classification to when classifier.backend === 'exapp'
+		'exapp.id' => 'recognize_exapp',
 	];
 
 	/** @var array<string,string>  */
@@ -86,7 +90,9 @@ final class SettingsService {
 		'landmarks.batchSize',
 		'movinet.batchSize',
 		'musicnn.batchSize',
-		'concurrency.enabled'
+		'concurrency.enabled',
+		'classifier.backend',
+		'exapp.id',
 	];
 
 	private IAppConfig $config;

--- a/src/components/ViewAdmin.vue
+++ b/src/components/ViewAdmin.vue
@@ -286,7 +286,54 @@
 				<a href="https://github.com/nextcloud/recognize/wiki/GPU-mode">{{ t('recognize', 'Learn how to setup GPU mode with Recognize') }}</a>
 			</p>
 		</NcSettingsSection>
-		<NcSettingsSection :name="t('recognize', 'Node.js')">
+		<NcSettingsSection :name="t('recognize', 'Classification backend')">
+			<p>
+				{{ t('recognize', 'By default, classification runs locally using the Node.js binary shipped with this app. Alternatively, you can offload classification to an External App (a container that can run on a different, more powerful machine, optionally with GPU support).') }}
+			</p>
+			<p>
+				<NcCheckboxRadioSwitch :model-value="settings['classifier.backend']"
+					value="local"
+					name="classifier_backend"
+					type="radio"
+					@update:model-value="onChangeBackend">
+					{{ t('recognize', 'Run classification locally (Node.js)') }}
+				</NcCheckboxRadioSwitch>
+				<NcCheckboxRadioSwitch :model-value="settings['classifier.backend']"
+					value="exapp"
+					name="classifier_backend"
+					type="radio"
+					:disabled="exapp === null"
+					@update:model-value="onChangeBackend">
+					{{ t('recognize', 'Offload classification to an External App') }}
+				</NcCheckboxRadioSwitch>
+			</p>
+			<template v-if="settings['classifier.backend'] === 'exapp'">
+				<NcNoteCard v-if="exapp === null" type="warning">
+					{{ t('recognize', 'The AppAPI app is not installed. It is required to use an External App as classification backend.') }}
+					<a href="https://apps.nextcloud.com/apps/app_api">{{ t('recognize', 'Install AppAPI') }}</a>
+				</NcNoteCard>
+				<p v-else-if="exapp === undefined">
+					<span class="icon-loading-small" />&nbsp;&nbsp;&nbsp;&nbsp;{{ t('recognize', 'Checking External App') }}
+				</p>
+				<NcNoteCard v-else-if="exapp === false" type="warning">
+					{{ t('recognize', 'The configured External App could not be reached. Install the "Recognize classification backend" app from the External Apps page and make sure it is deployed and enabled via AppAPI.') }}
+					<a href="https://apps.nextcloud.com/apps/recognize_exapp">{{ t('recognize', 'View on the App Store') }}</a>
+				</NcNoteCard>
+				<NcNoteCard v-else type="success">
+					{{ t('recognize', 'The External App is deployed and reachable (version {version}).', { version: exapp }) }}
+				</NcNoteCard>
+				<p>
+					{{ t('recognize', 'App ID of the recognize External App to use:') }}
+				</p>
+				<p>
+					<NcTextField v-model="settings['exapp.id']"
+						:label-visible="true"
+						:label="t('recognize', 'External App ID')"
+						@update:model-value="onChangeExAppId" />
+				</p>
+			</template>
+		</NcSettingsSection>
+		<NcSettingsSection v-if="settings['classifier.backend'] !== 'exapp'" :name="t('recognize', 'Node.js')">
 			<p v-if="nodejs === undefined">
 				<span class="icon-loading-small" />&nbsp;&nbsp;&nbsp;&nbsp;{{ t('recognize', 'Checking Node.js') }}
 			</p>
@@ -417,7 +464,7 @@ import { generateUrl } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
 import humanizeDuration from 'humanize-duration'
 
-const SETTINGS = ['tensorflow.cores', 'tensorflow.gpu', 'tensorflow.purejs', 'imagenet.enabled', 'landmarks.enabled', 'faces.enabled', 'musicnn.enabled', 'movinet.enabled', 'node_binary', 'ffmpeg_binary', 'faces.status', 'imagenet.status', 'landmarks.status', 'movinet.status', 'musicnn.status', 'faces.lastFile', 'imagenet.lastFile', 'landmarks.lastFile', 'movinet.lastFile', 'musicnn.lastFile', 'faces.batchSize', 'imagenet.batchSize', 'landmarks.batchSize', 'movinet.batchSize', 'musicnn.batchSize', 'clusterFaces.status', 'clusterFaces.lastRun', 'nice_binary', 'nice_value', 'concurrency.enabled']
+const SETTINGS = ['tensorflow.cores', 'tensorflow.gpu', 'tensorflow.purejs', 'imagenet.enabled', 'landmarks.enabled', 'faces.enabled', 'musicnn.enabled', 'movinet.enabled', 'node_binary', 'ffmpeg_binary', 'faces.status', 'imagenet.status', 'landmarks.status', 'movinet.status', 'musicnn.status', 'faces.lastFile', 'imagenet.lastFile', 'landmarks.lastFile', 'movinet.lastFile', 'musicnn.lastFile', 'faces.batchSize', 'imagenet.batchSize', 'landmarks.batchSize', 'movinet.batchSize', 'musicnn.batchSize', 'clusterFaces.status', 'clusterFaces.lastRun', 'nice_binary', 'nice_value', 'concurrency.enabled', 'classifier.backend', 'exapp.id']
 
 const BOOLEAN_SETTINGS = ['tensorflow.gpu', 'tensorflow.purejs', 'imagenet.enabled', 'landmarks.enabled', 'faces.enabled', 'musicnn.enabled', 'movinet.enabled', 'faces.status', 'imagenet.status', 'landmarks.status', 'movinet.status', 'musicnn.status', 'faces.lastFile', 'imagenet.lastFile', 'landmarks.lastFile', 'movinet.lastFile', 'musicnn.lastFile', 'clusterFaces.status', 'concurrency.enabled']
 
@@ -445,6 +492,7 @@ export default {
 			wasmtensorflow: undefined,
 			gputensorflow: undefined,
 			ffmpeg: undefined,
+			exapp: undefined,
 			cron: undefined,
 			modelsDownloaded: null,
 			imagenetJobs: null,
@@ -488,6 +536,7 @@ export default {
 		this.getMusl()
 		this.getNice()
 		this.getNodejsStatus()
+		this.getExAppStatus()
 		this.getFfmpegStatus()
 		this.getLibtensorflowStatus()
 		this.getWasmtensorflowStatus()
@@ -609,6 +658,12 @@ export default {
 			const { ffmpeg } = resp.data
 			this.ffmpeg = ffmpeg
 		},
+		async getExAppStatus() {
+			this.exapp = undefined
+			const resp = await axios.get(generateUrl('/apps/recognize/admin/exapp'))
+			const { exapp } = resp.data
+			this.exapp = exapp
+		},
 		async getLibtensorflowStatus() {
 			const resp = await axios.get(generateUrl('/apps/recognize/admin/libtensorflow'))
 			const { libtensorflow } = resp.data
@@ -641,6 +696,19 @@ export default {
 			setTimeout(() => {
 				this.submit()
 			}, 1000)
+		},
+
+		onChangeBackend(value) {
+			this.settings['classifier.backend'] = value
+			if (value === 'exapp') {
+				this.getExAppStatus()
+			}
+			this.onChange()
+		},
+
+		onChangeExAppId() {
+			this.getExAppStatus()
+			this.onChange()
 		},
 
 		async submit() {


### PR DESCRIPTION
Fixes #73

## Summary

Adds an option to offload Recognize's machine-learning classification to an **External App (ExApp)** container instead of running Node.js locally — so inference can run on a different, more powerful machine, optionally with a GPU. This is the long-requested "dedicated devices / Tensorflow-serving / ExApp backend" feature.

The design follows [marcelklehr's plan in the issue](https://github.com/nextcloud/recognize/issues/73#issuecomment-2100842279): keep the classifiers running the exact same `classifier_<model>.js` scripts, but add a setting that routes their execution to the Recognize ExApp via AppAPI rather than to a local process. Results are compatible because the same scripts are reused.

The ExApp is **installable from the Nextcloud App Store / External Apps page** (the default, recommended deployment), exactly like the other AI ExApps (`llm2`, `context_chat_backend`).

## How it works

```
┌───────────────────────┐      AppAPI (authenticated HTTP)        ┌──────────────────────────┐
│ Nextcloud + recognize  │ ── POST /classify (model + image bytes) ─▶│ recognize_exapp container │
│ (classifier.backend =  │                                          │  Node.js + Tensorflow.js  │
│        "exapp")        │ ◀── newline-delimited JSON results ────── │  classifier_<model>.js    │
└───────────────────────┘                                          └──────────────────────────┘
```

The PHP app prepares the same downscaled preview images it would feed to the local process, uploads them to the ExApp as multipart, and the container runs the unmodified classifier scripts and streams JSON results back. Image **bytes** are sent (not paths), so the ExApp can run on a remote machine that doesn't share the Nextcloud filesystem.

## Changes

**Recognize PHP app**
- `lib/Classifiers/Classifier.php` — `classifyFiles()` keeps file preparation + result parsing, but dispatches execution to `runLocally()` (the original `Symfony\Process` path, behavior unchanged) or `runExApp()` (uploads files to the ExApp via AppAPI) based on the new `classifier.backend` setting.
- `lib/Service/ExAppService.php` *(new)* — defensive wrapper around `OCA\AppAPI\PublicFunctions`. AppAPI is an **optional** dependency: every method degrades gracefully when it isn't installed, so the local backend keeps working.
- `lib/Service/SettingsService.php` — two new lazy settings: `classifier.backend` (`local`/`exapp`, default `local`) and `exapp.id` (default `recognize_exapp`).
- `lib/Controller/AdminController.php` + `appinfo/routes.php` — new `GET /admin/exapp` endpoint that tests ExApp reachability (mirrors the existing `nodejs()`/`ffmpeg()` checks).
- `src/components/ViewAdmin.vue` — new "Classification backend" admin section: local/ExApp radio selector, App-ID field, live status feedback, App Store install links.

**ExApp container (`exapp/`)**
- `server.js` — minimal HTTP server exposing `/heartbeat`, `/init`, `/enabled`, `/classify`; receives uploads, spawns the existing classifier scripts, streams results. AppAPI shared-secret auth.
- `Dockerfile` — self-contained, multi-stage; `BUILD_TYPE=cpu` (default) / `gpu` (CUDA base). Fetches the matching Recognize sources at build time.
- `appinfo/info.xml` — App Store ExApp manifest (registry image, env vars, AppAPI requirement).
- `Makefile`, `krankerl.toml`, `.nextcloudignore` — packaging / dev registration.
- `README.md` — architecture, install, build, release docs.
- `test/server.test.js` — standalone functional test for the server (no TensorFlow needed).

**CI (`.github/workflows/`)**
- `exapp-publish-docker.yml` — on `v*` tag, builds & pushes the image to `ghcr.io/nextcloud/recognize_exapp`.
- `exapp-appstore-build-publish.yml` — on release, packages, signs, and uploads the manifest to the App Store.

## Testing done locally

- **ExApp server: 13/13 functional tests pass** (auth, heartbeat, multipart parse, file ordering incl. out-of-order reassembly, model validation, error paths, lifecycle hooks) — `node exapp/test/server.test.js`.
- **PHP**: `php -l` clean on all 5 changed files; **php-cs-fixer clean** against the repo's pinned `nextcloud/coding-standard v1.1.0`.
- **Docker image**: builds successfully (CPU); container runs and serves `/heartbeat` → `200 {"status":"ok"}`.
- **Manifests/workflows**: XML well-formed (xmllint), workflow YAML parses, Dockerfile passes hadolint (advisory warnings only).

## Not covered / follow-ups

- **Psalm** and the **Vue build/eslint** weren't run locally (no full `composer install` / `node_modules`) — they run in CI.
- Only the **CPU image** was built (no local NVIDIA runtime for the GPU variant).
- The manifest pins `version`/`image-tag` `12.1.0`; the matching `v12.1.0` Recognize tag must exist at release time (CI keeps `RECOGNIZE_REF` in sync via the image-tag).
- The ExApp ships in-tree under `exapp/`; it may eventually warrant its own `nextcloud-releases` repo, but keeping it here makes the whole feature reviewable together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
