### PR TITLE
fix(FaceRoot): allow getChild to find face photos by plain filename

### DIFF
--- a/lib/Dav/Faces/FaceRoot.php
+++ b/lib/Dav/Faces/FaceRoot.php
@@ -106,18 +106,37 @@ final class FaceRoot implements ICollection, IMoveTarget {
 					return $child;
 				}
 			}
+			// Fallback: check against file basename only
+			foreach ($this->getChildren() as $child) {
+				if ($child->getName() === $name || $child->getFile()->getName() === $name) {
+					return $child;
+				}
+			}
 			throw new NotFound("$name not found");
 		}
 		[$detectionId,] = explode('-', $name);
-		try {
-			$detection = $this->detectionMapper->find((int)$detectionId);
-		} catch (DoesNotExistException $e) {
-			throw new NotFound();
+		if (is_numeric($detectionId)) {
+			try {
+				$detection = $this->detectionMapper->find((int)$detectionId);
+			} catch (DoesNotExistException $e) {
+				throw new NotFound();
+			}
+			if ($detection->getClusterId() !== $this->cluster->getId()) {
+				throw new NotFound();
+			}
+			return new FacePhoto($this->detectionMapper, $detection, $this->rootFolder->getUserFolder($this->user->getUID()), $this->tagManager, $this->previewManager);
 		}
-		if ($detection->getClusterId() !== $this->cluster->getId()) {
-			throw new NotFound();
+
+		$userFolder = $this->rootFolder->getUserFolder($this->user->getUID());
+		$detections = $this->detectionMapper->findByClusterId($this->cluster->getId());
+		$matching = array_values(array_filter($detections, function (FaceDetection $detection) use ($userFolder, $name) {
+			$file = $userFolder->getFirstNodeById($detection->getFileId());
+			return $file !== null && $file->getName() === $name;
+		}));
+		if (count($matching) === 0) {
+			throw new NotFound("$name not found");
 		}
-		return new FacePhoto($this->detectionMapper, $detection, $this->rootFolder->getUserFolder($this->user->getUID()), $this->tagManager, $this->previewManager);
+		return new FacePhoto($this->detectionMapper, $matching[0], $userFolder, $this->tagManager, $this->previewManager);
 	}
 
 	public function childExists($name): bool {


### PR DESCRIPTION
## Problem

When Nextcloud Photos sends a MOVE request to merge faces, it references children by their basename only (e.g. `photo.jpg`), not by the internal `{detectionId}-{filename}` pattern. This means a MOVE to `/recognize/{userId}/faces/{cluster}/photo.jpg` fails with 404 because `FaceRoot::getChild('photo.jpg')` cannot find the child.

The server-side moveInto() would succeed, but the DAV layer returns 404 on the source lookup, causing Photos to display an error (TypeError in `n.faceDetections.find(d => d.title === u)`) even though the operation completed on the server.

## Fix

Two fallback paths added to `getChild()`:

1. **Cached-children path** (when `$this->children` is already populated): after the primary match fails, iterate again and compare against `$child->getFile()->getName()`.

2. **Direct-DB path** (when cache is empty): guard with `is_numeric($detectionId)` before the numeric lookup to avoid breaking on plain filenames. If not numeric, query `findByClusterId()` and filter results by `$file->getName()` matching the requested basename.

Tested in production on Nextcloud 34 / Recognize 12.0.0. All MOVE operations return HTTP 201/204 and merges complete correctly.