### PR TITLE
fix: log model download URL and destination

### DIFF
--- a/lib/Command/DownloadModels.php
+++ b/lib/Command/DownloadModels.php
@@ -41,7 +41,9 @@ final class DownloadModels extends Command {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
-			$this->downloader->download();
+			$this->downloader->download(function (string $message) use ($output): void {
+				$output->writeln($message);
+			});
 		} catch (\Exception $ex) {
 			$output->writeln('<error>Failed to download models</error>');
 			$output->writeln($ex->getMessage());

--- a/lib/Service/DownloadModelsService.php
+++ b/lib/Service/DownloadModelsService.php
@@ -26,9 +26,12 @@ final class DownloadModelsService {
 	 * @return void
 	 * @throws \Exception
 	 */
-	public function download() : void {
+	public function download(?callable $log = null) : void {
+		$log ??= static function (string $message): void {
+		};
 		$targetPath = __DIR__ . '/../../models';
 		if (file_exists($targetPath)) {
+			$log('Removing existing models directory at ' . $targetPath);
 			// remove models directory
 			$it = new RecursiveDirectoryIterator($targetPath, FilesystemIterator::SKIP_DOTS);
 			$files = new RecursiveIteratorIterator($it,
@@ -45,8 +48,11 @@ final class DownloadModelsService {
 
 		$archiveUrl = $this->getArchiveUrl($this->getNeededArchiveRef());
 		$archivePath = __DIR__ . '/../../models.tar.gz';
+		$log('Downloading models archive from ' . $archiveUrl);
+		$log('Saving archive to ' . $archivePath);
 		$timeout = $this->isCLI ? 0 : 480;
 		$this->clientService->newClient()->get($archiveUrl, ['sink' => $archivePath, 'timeout' => $timeout]);
+		$log('Extracting models to ' . $targetPath);
 		$tarManager = new TAR($archivePath);
 		$tarFiles = $tarManager->getFiles();
 		$mainFolder = $tarFiles[0];

--- a/lib/Service/DownloadModelsService.php
+++ b/lib/Service/DownloadModelsService.php
@@ -23,6 +23,7 @@ final class DownloadModelsService {
 	}
 
 	/**
+	 * @param callable(string): void|null $log
 	 * @return void
 	 * @throws \Exception
 	 */


### PR DESCRIPTION
## Summary

Fixes #1403.

The `recognize:download-models` command previously did not show the model download URL and destination path.

This change adds optional logging to `DownloadModelsService::download()` and wires it to the console command output.

The command now reports:

- The existing models directory being removed
- The model archive download URL
- The archive destination path
- The model extraction path

This makes it possible to identify the exact URL and paths when the Nextcloud instance does not have direct Internet access.

## Testing

Tested locally with:

```bash
docker compose exec --user www-data nextcloud php occ recognize:download-models